### PR TITLE
Added MoveTo method

### DIFF
--- a/src/WinUIEx/HwndExtensions.cs
+++ b/src/WinUIEx/HwndExtensions.cs
@@ -153,29 +153,15 @@ namespace WinUIEx
             SetWindowPosOrThrow(new HWND(hwnd), new HWND(), (int)left, (int)top, w, h, SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW);
         }
 
-        /// <summary>
-        /// The edge positions MoveToPosition can move to
-        /// </summary>
-        public enum Positions
-        {
-            TopLeft,
-            TopCenter,
-            TopRight,
-            MiddleLeft,
-            MiddleCenter,
-            MiddleRight,
-            BottomLeft,
-            BottomCenter,
-            BottomRight
 
-        }
+
 
         /// <summary>
         /// Moves the window to the specified enum edge position on the current monitor.
         /// </summary>
         /// <param name="hwnd">The window handle</param>
         /// <param name="position">The enum edge position from Positions</param>
-        public static void MoveToPosition(IntPtr hwnd, Positions position)
+        public static void MoveTo(IntPtr hwnd, Placement position, double xOffset = 0, double yOffset = 0)
         {
             var hwndDesktop = PInvoke.MonitorFromWindow(new(hwnd), MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST);
             MONITORINFO info = new MONITORINFO();
@@ -193,51 +179,49 @@ namespace WinUIEx
 
             switch (position)
             {
-                case Positions.TopLeft:
+                case Placement.TopLeft:
                     left = 0;
-                    top = 0; 
+                    top = 0;
                     break;
-                case Positions.TopCenter:
-                    left = cx - (w/2);
-                    top = 0; 
+                case Placement.TopCenter:
+                    left = cx - (w / 2);
+                    top = 0;
                     break;
-                case Positions.TopRight:
+                case Placement.TopRight:
                     left = info.rcMonitor.right - w;
-                    top = 0; 
+                    top = 0;
                     break;
-                case Positions.MiddleLeft:
+                case Placement.MiddleLeft:
                     left = 0;
-                    top = cy - (h/2);
+                    top = cy - (h / 2);
                     break;
-                case Positions.MiddleCenter:
+                case Placement.MiddleCenter:
                     left = cx - (w / 2);
                     top = cy - (h / 2);
                     break;
-                case Positions.MiddleRight:
-                    left= info.rcMonitor.right - w;
+                case Placement.MiddleRight:
+                    left = info.rcMonitor.right - w;
                     top = cy - (h / 2);
                     break;
-                case Positions.BottomLeft:
+                case Placement.BottomLeft:
                     left = 0;
-                    top =  info.rcMonitor.bottom -h ;
+                    top = info.rcMonitor.bottom - h;
                     break;
-                case Positions.BottomCenter:
-                    left= cx - (w / 2);
-                    top =  info.rcMonitor.bottom -h ;
-                    break ;
-                case Positions.BottomRight:
+                case Placement.BottomCenter:
+                    left = cx - (w / 2);
+                    top = info.rcMonitor.bottom - h;
+                    break;
+                case Placement.BottomRight:
                     left = info.rcMonitor.right - w;
-                    top =  info.rcMonitor.bottom -h ;
+                    top = info.rcMonitor.bottom - h;
                     break;
                 default:
                     left = windowRect.left;
-                    top= windowRect.top;
+                    top = windowRect.top;
                     break;
             }
-            SetWindowPosOrThrow(new HWND(hwnd), new HWND(), (int)left, (int)top, w, h, SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW);
+            SetWindowPosOrThrow(new HWND(hwnd), new HWND(), (int)(left + xOffset), (int)(top + yOffset), w, h, SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW);
         }
-
-
 
 
         /// <summary>

--- a/src/WinUIEx/HwndExtensions.cs
+++ b/src/WinUIEx/HwndExtensions.cs
@@ -115,6 +115,115 @@ namespace WinUIEx
             SetWindowPosOrThrow(new HWND(hwnd), new HWND(), left, top, w, h, SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW);
         }
 
+
+            public static void MoveToPoint(IntPtr hwnd, double x, double y)
+        {
+            PInvoke.GetWindowRect(new HWND(hwnd), out RECT windowRect);
+            var w = windowRect.right - windowRect.left;
+            var h = windowRect.bottom - windowRect.top;
+            var left = x;
+            var top = y;
+            SetWindowPosOrThrow(new HWND(hwnd), new HWND(), (int)left, (int)top, w, h, SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW);
+        }
+
+        public static void CenterOnPoint(IntPtr hwnd, double x, double y, double? width = null, double? height = null)
+        {
+            var dpi = PInvoke.GetDpiForWindow(new HWND(hwnd));
+            PInvoke.GetWindowRect(new HWND(hwnd), out RECT windowRect);
+            var scalingFactor = dpi / 96d;
+            var w = width.HasValue ? (int)(width * scalingFactor) : windowRect.right - windowRect.left;
+            var h = height.HasValue ? (int)(height * scalingFactor) : windowRect.bottom - windowRect.top;
+            var cx = x;
+            var cy = y;
+            var left = cx - (w / 2);
+            var top = cy - (h / 2);
+            SetWindowPosOrThrow(new HWND(hwnd), new HWND(), (int)left, (int)top, w, h, SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW);
+        }
+
+        /// <summary>
+        /// The positions MoveToPosition can move to
+        /// </summary>
+        public enum Positions
+        {
+            TopLeft,
+            TopCenter,
+            TopRight,
+            MiddleLeft,
+            MiddleCenter,
+            MiddleRight,
+            BottomLeft,
+            BottomCenter,
+            BottomRight
+
+        }
+
+        public static void MoveToPosition(IntPtr hwnd, Positions position)
+        {
+            var hwndDesktop = PInvoke.MonitorFromWindow(new(hwnd), MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST);
+            MONITORINFO info = new MONITORINFO();
+            info.cbSize = 40;
+            PInvoke.GetMonitorInfo(hwndDesktop, ref info);
+            var dpi = PInvoke.GetDpiForWindow(new HWND(hwnd));
+            PInvoke.GetWindowRect(new HWND(hwnd), out RECT windowRect);
+            var scalingFactor = dpi / 96d;
+
+            int w = windowRect.right - windowRect.left;
+            int h = windowRect.bottom - windowRect.top;
+            var cx = (info.rcMonitor.left + info.rcMonitor.right) / 2;
+            var cy = (info.rcMonitor.bottom + info.rcMonitor.top) / 2;
+            double left; double top;
+
+            switch (position)
+            {
+                case Positions.TopLeft:
+                    left = 0;
+                    top = 0; 
+                    break;
+                case Positions.TopCenter:
+                    left = cx - (w/2);
+                    top = 0; 
+                    break;
+                case Positions.TopRight:
+                    left = info.rcMonitor.right - w;
+                    top = 0; 
+                    break;
+                case Positions.MiddleLeft:
+                    left = 0;
+                    top = cy - (h/2);
+                    break;
+                case Positions.MiddleCenter:
+                    left = cx - (w / 2);
+                    top = cy - (h / 2);
+                    break;
+                case Positions.MiddleRight:
+                    left= info.rcMonitor.right - w;
+                    top = cy - (h / 2);
+                    break;
+                case Positions.BottomLeft:
+                    left = 0;
+                    top =  info.rcMonitor.bottom -h ;
+                    break;
+                case Positions.BottomCenter:
+                    left= cx - (w / 2);
+                    top =  info.rcMonitor.bottom -h ;
+                    break ;
+                case Positions.BottomRight:
+                    left = info.rcMonitor.right - w;
+                    top =  info.rcMonitor.bottom -h ;
+                    break;
+                default:
+                    left = windowRect.left;
+                    top= windowRect.top;
+                    break;
+            }
+            SetWindowPosOrThrow(new HWND(hwnd), new HWND(), (int)left, (int)top, w, h, SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW);
+
+
+        }
+
+
+
+
         /// <summary>
         /// Sets the icon for the window, using the specified icon ID.
         /// </summary>

--- a/src/WinUIEx/HwndExtensions.cs
+++ b/src/WinUIEx/HwndExtensions.cs
@@ -161,7 +161,8 @@ namespace WinUIEx
         /// </summary>
         /// <param name="hwnd">The window handle</param>
         /// <param name="position">The enum edge position from Positions</param>
-        public static void MoveTo(IntPtr hwnd, Placement position, double xOffset = 0, double yOffset = 0)
+        /// <param name="forceTowardsCenter">Forces the window away from edge and towards the center by absolute XY values</param>
+        public static void MoveTo(IntPtr hwnd, Placement position, double xOffset, double yOffset, bool forceTowardsCenter = false)
         {
             var hwndDesktop = PInvoke.MonitorFromWindow(new(hwnd), MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST);
             MONITORINFO info = new MONITORINFO();
@@ -219,6 +220,51 @@ namespace WinUIEx
                     left = windowRect.left;
                     top = windowRect.top;
                     break;
+            }
+
+            if (forceTowardsCenter)
+            {
+                switch (position)
+                {
+                    case Placement.TopLeft:
+                        xOffset = +xOffset;
+                        yOffset = +yOffset;
+                        break;
+                    case Placement.TopCenter:
+                        xOffset = 0;
+                        yOffset = +yOffset;
+                        break;
+                    case Placement.TopRight:
+                        xOffset = -xOffset;
+                        yOffset = +yOffset;
+                        break;
+                    case Placement.MiddleLeft:
+                        xOffset = +xOffset;
+                        yOffset = 0;
+                        break;
+                    case Placement.MiddleCenter:
+                        xOffset = 0;
+                        yOffset = 0;
+                        break;
+                    case Placement.MiddleRight:
+                        xOffset = -xOffset;
+                        yOffset = 0;
+                        break;
+                    case Placement.BottomLeft:
+                        xOffset = +xOffset;
+                        yOffset = -yOffset;
+                        break;
+                    case Placement.BottomCenter:
+                        xOffset = 0;
+                        yOffset = -yOffset;
+                        break;
+                    case Placement.BottomRight:
+                        xOffset = -xOffset;
+                        yOffset = -yOffset;
+                        break;
+                    default:
+                        break;
+                }
             }
             SetWindowPosOrThrow(new HWND(hwnd), new HWND(), (int)(left + xOffset), (int)(top + yOffset), w, h, SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW);
         }

--- a/src/WinUIEx/HwndExtensions.cs
+++ b/src/WinUIEx/HwndExtensions.cs
@@ -116,23 +116,7 @@ namespace WinUIEx
         }
 
         /// <summary>
-        /// Moves the window to the specified coordinates
-        /// </summary>
-        /// <param name="hwnd">Window handle</param>
-        /// <param name="x">Left side of the window</param>
-        /// <param name="y">Top side of the window</param>
-        public static void MoveToPoint(IntPtr hwnd, double x, double y)
-        {
-            PInvoke.GetWindowRect(new HWND(hwnd), out RECT windowRect);
-            var w = windowRect.right - windowRect.left;
-            var h = windowRect.bottom - windowRect.top;
-            var left = x;
-            var top = y;
-            SetWindowPosOrThrow(new HWND(hwnd), new HWND(), (int)left, (int)top, w, h, SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW);
-        }
-
-        /// <summary>
-        /// 
+        /// Centers the window on a specified point
         /// </summary>
         /// <param name="hwnd"></param>
         /// <param name="x"></param>
@@ -152,9 +136,6 @@ namespace WinUIEx
             var top = cy - (h / 2);
             SetWindowPosOrThrow(new HWND(hwnd), new HWND(), (int)left, (int)top, w, h, SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW);
         }
-
-
-
 
         /// <summary>
         /// Moves the window to the specified enum edge position on the current monitor.

--- a/src/WinUIEx/HwndExtensions.cs
+++ b/src/WinUIEx/HwndExtensions.cs
@@ -115,8 +115,13 @@ namespace WinUIEx
             SetWindowPosOrThrow(new HWND(hwnd), new HWND(), left, top, w, h, SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW);
         }
 
-
-            public static void MoveToPoint(IntPtr hwnd, double x, double y)
+        /// <summary>
+        /// Moves the window to the specified coordinates
+        /// </summary>
+        /// <param name="hwnd">Window handle</param>
+        /// <param name="x">Left side of the window</param>
+        /// <param name="y">Top side of the window</param>
+        public static void MoveToPoint(IntPtr hwnd, double x, double y)
         {
             PInvoke.GetWindowRect(new HWND(hwnd), out RECT windowRect);
             var w = windowRect.right - windowRect.left;
@@ -126,6 +131,14 @@ namespace WinUIEx
             SetWindowPosOrThrow(new HWND(hwnd), new HWND(), (int)left, (int)top, w, h, SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW);
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="hwnd"></param>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <param name="width"></param>
+        /// <param name="height"></param>
         public static void CenterOnPoint(IntPtr hwnd, double x, double y, double? width = null, double? height = null)
         {
             var dpi = PInvoke.GetDpiForWindow(new HWND(hwnd));
@@ -141,7 +154,7 @@ namespace WinUIEx
         }
 
         /// <summary>
-        /// The positions MoveToPosition can move to
+        /// The edge positions MoveToPosition can move to
         /// </summary>
         public enum Positions
         {
@@ -157,6 +170,11 @@ namespace WinUIEx
 
         }
 
+        /// <summary>
+        /// Moves the window to the specified enum edge position on the current monitor.
+        /// </summary>
+        /// <param name="hwnd">The window handle</param>
+        /// <param name="position">The enum edge position from Positions</param>
         public static void MoveToPosition(IntPtr hwnd, Positions position)
         {
             var hwndDesktop = PInvoke.MonitorFromWindow(new(hwnd), MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST);
@@ -217,8 +235,6 @@ namespace WinUIEx
                     break;
             }
             SetWindowPosOrThrow(new HWND(hwnd), new HWND(), (int)left, (int)top, w, h, SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW);
-
-
         }
 
 

--- a/src/WinUIEx/Placement.cs
+++ b/src/WinUIEx/Placement.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WinUIEx
+{
+    /// <summary>
+    /// The edge positions MoveToPosition can move to
+    /// </summary>
+    public enum Placement
+    {
+        TopLeft,
+        TopCenter,
+        TopRight,
+        MiddleLeft,
+        MiddleCenter,
+        MiddleRight,
+        BottomLeft,
+        BottomCenter,
+        BottomRight
+    }
+}

--- a/src/WinUIEx/Placement.cs
+++ b/src/WinUIEx/Placement.cs
@@ -7,18 +7,47 @@ using System.Threading.Tasks;
 namespace WinUIEx
 {
     /// <summary>
-    /// The edge positions MoveToPosition can move to
+    /// The edge positions MoveTo can move to
     /// </summary>
+    /// <seealso cref="HwndExtensions.MoveTo" />
+    /// <seealso cref="WindowExtensions.MoveTo" />
     public enum Placement
     {
+        /// <summary>
+        /// The top far left corner of the screen.
+        /// </summary>
         TopLeft,
+        /// <summary>
+        /// The top of the screen and half way across the width.
+        /// </summary>
         TopCenter,
+        /// <summary>
+        /// The top far right corner of the screen.
+        /// </summary>
         TopRight,
+        /// <summary>
+        /// The far left side of the screen, half way down the height
+        /// </summary>
         MiddleLeft,
+        /// <summary>
+        /// The middle of the screen.
+        /// </summary>
         MiddleCenter,
+        /// <summary>
+        /// The far right side of screen, half way down the height.
+        /// </summary>
         MiddleRight,
+        /// <summary>
+        /// The bottom far left corner of the screen.
+        /// </summary>
         BottomLeft,
+        /// <summary>
+        /// The bottom of the screen, and half way across the width.
+        /// </summary>
         BottomCenter,
+        /// <summary>
+        /// The bottom far right corner of the screen.
+        /// </summary>
         BottomRight
     }
 }

--- a/src/WinUIEx/WindowEx.cs
+++ b/src/WinUIEx/WindowEx.cs
@@ -346,6 +346,8 @@ namespace WinUIEx
             set => AppWindow.IsShownInSwitchers = value;
         }
 
+
+
         /// <summary>
         /// Gets or sets a value indicating whether this window is shown in task switchers.
         /// </summary>
@@ -437,6 +439,18 @@ namespace WinUIEx
                     Height = value;
             }
         }
+
+        private bool _IsForcedTowardsCenter = false;
+        /// <summary>
+        /// A bool to set whether offsets are forced away from the specified edge 
+        /// </summary>
+        public bool IsForcedTowardsCenter
+        {
+            get => _IsForcedTowardsCenter;
+            set => _IsForcedTowardsCenter = value;
+        }
+
+
 
         /// <summary>
         /// Raised if the window position changes.

--- a/src/WinUIEx/WindowEx.cs
+++ b/src/WinUIEx/WindowEx.cs
@@ -440,18 +440,6 @@ namespace WinUIEx
             }
         }
 
-        private bool _IsForcedTowardsCenter = false;
-        /// <summary>
-        /// A bool to set whether offsets are forced away from the specified edge 
-        /// </summary>
-        public bool IsForcedTowardsCenter
-        {
-            get => _IsForcedTowardsCenter;
-            set => _IsForcedTowardsCenter = value;
-        }
-
-
-
         /// <summary>
         /// Raised if the window position changes.
         /// </summary>

--- a/src/WinUIEx/WindowExtensions.cs
+++ b/src/WinUIEx/WindowExtensions.cs
@@ -166,8 +166,7 @@ namespace WinUIEx
         /// <param name="window">The window that is to be moved</param>
         /// <param name="position">the enum for the position</param>
         public static void MoveTo(this Microsoft.UI.Xaml.Window window, Placement position)
-            => HwndExtensions.MoveTo(window.GetWindowHandle(), position);
-
+            => HwndExtensions.MoveTo(window.GetWindowHandle(), position, 0, 0, false);
 
         /// <summary>
         /// Moves Window to the enum specified edge of the screen, adjusted by xy co-ordinanates.  
@@ -176,9 +175,20 @@ namespace WinUIEx
         /// <param name="relativeTo">The Placement enum the window will be moved relative to</param>
         /// <param name="xOffset">Positive values move right, negative values move left</param>
         /// <param name="yOffset">Positive values move down, negative values move up</param>
-        public static void MoveTo(this Microsoft.UI.Xaml.Window window, Placement relativeTo, double xOffset = 0, double yOffset = 0)
+        public static void MoveTo(this Microsoft.UI.Xaml.Window window, Placement relativeTo, double xOffset, double yOffset)
             => HwndExtensions.MoveTo(window.GetWindowHandle(), relativeTo, xOffset,yOffset );
 
+
+        /// <summary>
+        /// Moves Window to the enum specified edge of the screen  
+        /// </summary>
+        /// <param name="window"></param>
+        /// <param name="relativeTo">The Placement enum the window will be moved relative to</param>
+        /// <param name="xOffset">The x-axis value to move away from the edge</param>
+        /// <param name="yOffset">The y-axis value to move away from the edge </param>
+        /// <param name="forceTowardsCenter">Forces the window away from edge and towards the center by absolute XY values</param>
+        public static void MoveTo(this Microsoft.UI.Xaml.Window window, Placement relativeTo, double xOffset, double yOffset, bool forceTowardsCenter)
+            => HwndExtensions.MoveTo(window.GetWindowHandle(), relativeTo, xOffset, yOffset, forceTowardsCenter);
 
         /// <summary>
         /// Positions the window without resizing, Window will be centred around the point.
@@ -309,5 +319,6 @@ namespace WinUIEx
             appWindow.TitleBar.ButtonPressedBackgroundColor = color;
             appWindow.TitleBar.InactiveBackgroundColor = color;
         }
+
     }
 }

--- a/src/WinUIEx/WindowExtensions.cs
+++ b/src/WinUIEx/WindowExtensions.cs
@@ -150,6 +150,19 @@ namespace WinUIEx
             => window.GetAppWindow().MoveAndResize(new Windows.Graphics.RectInt32((int)x, (int)y, (int)width, (int)height)); // TODO: Adjust for dpi
             //=> HwndExtensions.SetWindowPositionAndSize(window.GetWindowHandle(), x, y, width, height);
 
+
+   
+        public static void Move(this Microsoft.UI.Xaml.Window window, double x, double y) 
+            => HwndExtensions.MoveToPoint(window.GetWindowHandle(), x, y);
+
+        public static void MoveToSelectedPosition(this Microsoft.UI.Xaml.Window window, HwndExtensions.Positions position)
+            => HwndExtensions.MoveToPosition(window.GetWindowHandle(), position);
+
+
+        public static void CenterOnPoint(this Microsoft.UI.Xaml.Window window, double x, double y, double? width = null, double? height = null)
+    => HwndExtensions.CenterOnPoint(window.GetWindowHandle(),x, y, width, height);
+
+
         /// <summary>
         /// Sets the width and height of the window in device-independent pixels.
         /// </summary>

--- a/src/WinUIEx/WindowExtensions.cs
+++ b/src/WinUIEx/WindowExtensions.cs
@@ -157,16 +157,27 @@ namespace WinUIEx
         /// <param name="window">The window to be moved</param>
         /// <param name="x">Left side of the window</param>
         /// <param name="y">Top side of the window</param>
-        public static void Move(this Microsoft.UI.Xaml.Window window, double x, double y) 
-            => HwndExtensions.MoveToPoint(window.GetWindowHandle(), x, y);
+        public static void MoveTo(this Microsoft.UI.Xaml.Window window, double x, double y) 
+            => HwndExtensions.MoveTo(window.GetWindowHandle(), Placement.TopLeft, x, y);
 
         /// <summary>
         /// Moves the window to the enum specified edge of the screen
         /// </summary>
         /// <param name="window">The window that is to be moved</param>
         /// <param name="position">the enum for the position</param>
-        public static void MoveToPosition(this Microsoft.UI.Xaml.Window window, HwndExtensions.Positions position)
-            => HwndExtensions.MoveToPosition(window.GetWindowHandle(), position);
+        public static void MoveTo(this Microsoft.UI.Xaml.Window window, Placement position)
+            => HwndExtensions.MoveTo(window.GetWindowHandle(), position);
+
+
+        /// <summary>
+        /// Moves Window to the enum specified edge of the screen, adjusted by xy co-ordinanates.  
+        /// </summary>
+        /// <param name="window"></param>
+        /// <param name="relativeTo">The Placement enum the window will be moved relative to</param>
+        /// <param name="xOffset">Positive values move right, negative values move left</param>
+        /// <param name="yOffset">Positive values move down, negative values move up</param>
+        public static void MoveTo(this Microsoft.UI.Xaml.Window window, Placement relativeTo, double xOffset = 0, double yOffset = 0)
+            => HwndExtensions.MoveTo(window.GetWindowHandle(), relativeTo, xOffset,yOffset );
 
 
         /// <summary>

--- a/src/WinUIEx/WindowExtensions.cs
+++ b/src/WinUIEx/WindowExtensions.cs
@@ -151,14 +151,30 @@ namespace WinUIEx
             //=> HwndExtensions.SetWindowPositionAndSize(window.GetWindowHandle(), x, y, width, height);
 
 
-   
+        /// <summary>
+        /// Positions the window without resizing. Window will be below and right of the specified coordinates.
+        /// </summary>
+        /// <param name="window">The window to be moved</param>
+        /// <param name="x">Left side of the window</param>
+        /// <param name="y">Top side of the window</param>
         public static void Move(this Microsoft.UI.Xaml.Window window, double x, double y) 
             => HwndExtensions.MoveToPoint(window.GetWindowHandle(), x, y);
 
-        public static void MoveToSelectedPosition(this Microsoft.UI.Xaml.Window window, HwndExtensions.Positions position)
+        /// <summary>
+        /// Moves the window to the enum specified edge of the screen
+        /// </summary>
+        /// <param name="window">The window that is to be moved</param>
+        /// <param name="position">the enum for the position</param>
+        public static void MoveToPosition(this Microsoft.UI.Xaml.Window window, HwndExtensions.Positions position)
             => HwndExtensions.MoveToPosition(window.GetWindowHandle(), position);
 
 
+        /// <summary>
+        /// Positions the window without resizing, Window will be centred around the point.
+        /// </summary>
+        /// <param name="window">The window to be moved</param>
+        /// <param name="x">Left side of the window</param>
+        /// <param name="y">Top side of the window</param>
         public static void CenterOnPoint(this Microsoft.UI.Xaml.Window window, double x, double y, double? width = null, double? height = null)
     => HwndExtensions.CenterOnPoint(window.GetWindowHandle(),x, y, width, height);
 

--- a/src/WinUIExSample/MainWindow.xaml
+++ b/src/WinUIExSample/MainWindow.xaml
@@ -35,6 +35,8 @@
                     <ComboBoxItem>Compact</ComboBoxItem>
                     <ComboBoxItem>Fullscren</ComboBoxItem>
                 </ComboBox>
+                <ToggleSwitch Header="Force Towards Center" IsOn="{x:Bind IsForcedTowardsCenter, Mode=TwoWay}"/>
+
             </StackPanel>
         </ScrollViewer>
         <ScrollViewer Grid.Column="1">

--- a/src/WinUIExSample/MainWindow.xaml
+++ b/src/WinUIExSample/MainWindow.xaml
@@ -102,6 +102,7 @@
                         Click="moveWindowButton_Clicked"
                         Content="BottomRight" />
                 </Grid>
+                <TextBlock Foreground="Gray"  HorizontalAlignment="Center">If above pressed, adjust by the below XY values</TextBlock>
                 <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
                     <TextBlock VerticalAlignment="Center" Text="X: " />
                     <NumberBox

--- a/src/WinUIExSample/MainWindow.xaml
+++ b/src/WinUIExSample/MainWindow.xaml
@@ -2,16 +2,14 @@
     x:Class="WinUIExSample.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:WinUIExSample"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:winex="using:WinUIEx"
-    Title="WinUI EX Test App"
-    Width="1024"
-    Height="768"
-    MinWidth="500"
-    MinHeight="250"
     TaskBarIcon="Images/WindowIcon.ico"
+    Title="WinUI EX Test App"
+    Width="1024" Height="768"
+    MinWidth="500" MinHeight="250"
     mc:Ignorable="d">
 
     <!--<winex:WindowEx.TitleBarIcon>
@@ -22,7 +20,7 @@
         <TextBlock Text="WinUI Window Extensions" VerticalAlignment="Center" />
     </winex:WindowEx.TitleBar>-->
 
-    <Grid Margin="20" ColumnDefinitions="Auto,Auto,*">
+    <Grid ColumnDefinitions="Auto,Auto,*" Margin="20">
         <ScrollViewer>
             <StackPanel>
                 <ToggleSwitch Header="Can Minimize" IsOn="{x:Bind IsMinimizable, Mode=TwoWay}" />
@@ -32,17 +30,13 @@
                 <ToggleSwitch Header="Always On Top" IsOn="{x:Bind IsAlwaysOnTop, Mode=TwoWay}" />
                 <ToggleSwitch Header="Set Custom Titlebar" Toggled="CustomTitleBar_Toggled" />
                 <ToggleSwitch Header="Subscribe To Window Messages" Toggled="WMMessages_Toggled" />
-                <ComboBox
-                    Header="Presenter"
-                    SelectedIndex="0"
-                    SelectionChanged="Presenter_SelectionChanged">
+                <ComboBox Header="Presenter" SelectedIndex="0" SelectionChanged="Presenter_SelectionChanged">
                     <ComboBoxItem>Overlapped</ComboBoxItem>
                     <ComboBoxItem>Compact</ComboBoxItem>
-                    <ComboBoxItem>Fullscreen</ComboBoxItem>
+                    <ComboBoxItem>Fullscren</ComboBoxItem>
                 </ComboBox>
             </StackPanel>
         </ScrollViewer>
-
         <ScrollViewer Grid.Column="1">
             <StackPanel>
                 <StackPanel.Resources>
@@ -52,38 +46,18 @@
                     </Style>
                 </StackPanel.Resources>
                 <TextBox Header="Title:" Text="{x:Bind Title, Mode=TwoWay}" />
-                <Slider
-                    Header="Minimum Width"
-                    Maximum="1024"
-                    Minimum="139"
-                    Value="{x:Bind MinWidth, Mode=TwoWay}" />
-                <Slider
-                    Header="Minimum Height"
-                    Maximum="768"
-                    Minimum="39"
-                    Value="{x:Bind MinHeight, Mode=TwoWay}" />
-                <Button Click="Center_Click" Content="Center On Screen" />
-                <Button Click="MaximizeWindow_Click" Content="Maximize" />
-                <Button Click="RestoreWindow_Click" Content="Restore" />
-                <Button Click="MinimizeWindow_Click" Content="Minimize + Restore (2 second delay)" />
-                <Button Click="HideWindow_Click" Content="Hide + Restore (2 second delay)" />
-                <Button Click="ToggleTrayIcon_Click" Content="Toggle Tray Icon" />
-                <Button Click="MinimizeTrayIcon_Click" Content="Minimize to tray (click tray to reopen)" />
-                <Button Click="BringToFront_Click" Content="Bring to front (2 second delay)" />
-                <Button Click="ShowDialog_Click" Content="Show dialog" />
-                <!--<RadioButtons MaxColumns="3" Header="Move Window To: " >
-                <RadioButton Content="TopLeft"  Checked="moveWindowRadioButtons_Checked"/>
-                <RadioButton Content="TopCenter"  Checked="moveWindowRadioButtons_Checked"/>
-                <RadioButton Content="TopRight"  Checked="moveWindowRadioButtons_Checked"/>
+                <Slider Header="Minimum Width" Maximum="1024" Minimum="139" Value="{x:Bind MinWidth, Mode=TwoWay}" />
+                <Slider Header="Minimum Height" Maximum="768" Minimum="39" Value="{x:Bind MinHeight, Mode=TwoWay}" />
+                <Button Content="Center On Screen" Click="Center_Click" />
+                <Button Content="Maximize" Click="MaximizeWindow_Click" />
+                <Button Content="Restore" Click="RestoreWindow_Click" />
+                <Button Content="Minimize + Restore (2 second delay)" Click="MinimizeWindow_Click" />
+                <Button Content="Hide + Restore (2 second delay)" Click="HideWindow_Click" />
+                <Button Content="Toggle Tray Icon" Click="ToggleTrayIcon_Click" />
+                <Button Content="Minimime to tray (click tray to reopen)" Click="MinimizeTrayIcon_Click" />
+                <Button Content="Bring to front (2 second delay)" Click="BringToFront_Click" />
+                <Button Content="Show dialog" Click="ShowDialog_Click" />
 
-                <RadioButton Content="MiddleLeft"  Checked="moveWindowRadioButtons_Checked"/>
-                <RadioButton Content="MiddleCenter"  Checked="moveWindowRadioButtons_Checked"/>
-                <RadioButton Content="MiddleRight"   Checked="moveWindowRadioButtons_Checked"/>
-
-                <RadioButton Content="BottomLeft"  Checked="moveWindowRadioButtons_Checked"/>
-                <RadioButton Content="BottomCenter"  Checked="moveWindowRadioButtons_Checked"/>
-                <RadioButton Content="BottomRight" Checked="moveWindowRadioButtons_Checked"/>
-                </RadioButtons>-->
                 <TextBlock Text="Move Window To:" />
                 <Grid ColumnDefinitions="*,*,*" RowDefinitions="*,*,*">
                     <Button Click="moveWindowButton_Clicked" Content="TopLeft" />
@@ -125,41 +99,31 @@
                         Grid.Column="2"
                         Click="moveWindowButton_Clicked"
                         Content="BottomRight" />
-
                 </Grid>
-
-
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                    <TextBlock VerticalAlignment="Center" Text="X: "/>
+                <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
+                    <TextBlock VerticalAlignment="Center" Text="X: " />
                     <NumberBox
                         x:Name="x_box"
                         Width="100"
-                        Value="300" 
-                        Margin="5"/>
-                    <TextBlock VerticalAlignment="Center" Text="Y: "/>
+                        Margin="5"
+                        Value="0" />
+                    <TextBlock VerticalAlignment="Center" Text="Y: " />
                     <NumberBox
                         x:Name="y_box"
                         Width="100"
-                        Value="300" 
-                        Margin="5"/>
+                        Margin="5"
+                        Value="0" />
                 </StackPanel>
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                <Button Click="MoveToPoint_Click" Content="Move to XY" />
-                <Button Click="CentreOnPoint_Click" Content="Centre on XY" />                    
+                <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
+                    <Button Click="MoveToPoint_Click" Content="Move to XY" />
+                    <Button Click="CentreOnPoint_Click" Content="Centre on XY" />
                 </StackPanel>
-
             </StackPanel>
         </ScrollViewer>
 
-        <Grid Grid.Column="2" RowDefinitions="Auto,*">
+        <Grid Grid.Column="2" RowDefinitions="Auto,*" >
             <TextBlock Text="Log" />
-            <TextBox
-                x:Name="WindowEventLog"
-                Grid.Row="1"
-                HorizontalAlignment="Stretch"
-                VerticalAlignment="Stretch"
-                AcceptsReturn="True"
-                IsReadOnly="True" />
+            <TextBox IsReadOnly="True" AcceptsReturn="True" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" x:Name="WindowEventLog" Grid.Row="1" />
         </Grid>
 
     </Grid>

--- a/src/WinUIExSample/MainWindow.xaml
+++ b/src/WinUIExSample/MainWindow.xaml
@@ -2,16 +2,18 @@
     x:Class="WinUIExSample.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WinUIExSample"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WinUIExSample"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:winex="using:WinUIEx"
-    TaskBarIcon="Images/WindowIcon.ico"
     Title="WinUI EX Test App"
-    Width="1024" Height="768"
-    MinWidth="500" MinHeight="250"
+    Width="1024"
+    Height="768"
+    MinWidth="500"
+    MinHeight="250"
+    TaskBarIcon="Images/WindowIcon.ico"
     mc:Ignorable="d">
-    
+
     <!--<winex:WindowEx.TitleBarIcon>
         <BitmapImage UriSource="ms-appx:///Images/WindowIcon.gif" DecodePixelHeight="32" />
     </winex:WindowEx.TitleBarIcon>-->
@@ -20,47 +22,145 @@
         <TextBlock Text="WinUI Window Extensions" VerticalAlignment="Center" />
     </winex:WindowEx.TitleBar>-->
 
-    <Grid ColumnDefinitions="Auto,Auto,*" Margin="20">
+    <Grid Margin="20" ColumnDefinitions="Auto,Auto,*">
         <ScrollViewer>
-        <StackPanel>
-            <ToggleSwitch Header="Can Minimize" IsOn="{x:Bind IsMinimizable, Mode=TwoWay}" />
-            <ToggleSwitch Header="Can Maximize" IsOn="{x:Bind IsMaximizable, Mode=TwoWay}" />
-            <ToggleSwitch Header="Can Resize" IsOn="{x:Bind IsResizable, Mode=TwoWay}" />
-            <ToggleSwitch Header="Is Titlebar Visible" IsOn="{x:Bind IsTitleBarVisible, Mode=TwoWay}" />
-            <ToggleSwitch Header="Always On Top" IsOn="{x:Bind IsAlwaysOnTop, Mode=TwoWay}" />
-            <ToggleSwitch Header="Set Custom Titlebar" Toggled="CustomTitleBar_Toggled" />
-            <ToggleSwitch Header="Subscribe To Window Messages" Toggled="WMMessages_Toggled" />
-            <ComboBox Header="Presenter" SelectedIndex="0" SelectionChanged="Presenter_SelectionChanged">
-                <ComboBoxItem>Overlapped</ComboBoxItem>
-                <ComboBoxItem>Compact</ComboBoxItem>
-                <ComboBoxItem>Fullscren</ComboBoxItem>
-            </ComboBox>
-        </StackPanel>
+            <StackPanel>
+                <ToggleSwitch Header="Can Minimize" IsOn="{x:Bind IsMinimizable, Mode=TwoWay}" />
+                <ToggleSwitch Header="Can Maximize" IsOn="{x:Bind IsMaximizable, Mode=TwoWay}" />
+                <ToggleSwitch Header="Can Resize" IsOn="{x:Bind IsResizable, Mode=TwoWay}" />
+                <ToggleSwitch Header="Is Titlebar Visible" IsOn="{x:Bind IsTitleBarVisible, Mode=TwoWay}" />
+                <ToggleSwitch Header="Always On Top" IsOn="{x:Bind IsAlwaysOnTop, Mode=TwoWay}" />
+                <ToggleSwitch Header="Set Custom Titlebar" Toggled="CustomTitleBar_Toggled" />
+                <ToggleSwitch Header="Subscribe To Window Messages" Toggled="WMMessages_Toggled" />
+                <ComboBox
+                    Header="Presenter"
+                    SelectedIndex="0"
+                    SelectionChanged="Presenter_SelectionChanged">
+                    <ComboBoxItem>Overlapped</ComboBoxItem>
+                    <ComboBoxItem>Compact</ComboBoxItem>
+                    <ComboBoxItem>Fullscreen</ComboBoxItem>
+                </ComboBox>
+            </StackPanel>
         </ScrollViewer>
-        <StackPanel Grid.Column="1">
-            <StackPanel.Resources>
-                <Style TargetType="Button">
-                    <Setter Property="HorizontalAlignment" Value="Stretch" />
-                    <Setter Property="Margin" Value="5" />
-                </Style>
-            </StackPanel.Resources>
-            <TextBox Header="Title:" Text="{x:Bind Title, Mode=TwoWay}" />
-            <Slider Header="Minimum Width" Maximum="1024" Minimum="139" Value="{x:Bind MinWidth, Mode=TwoWay}" />
-            <Slider Header="Minimum Height" Maximum="768" Minimum="39" Value="{x:Bind MinHeight, Mode=TwoWay}" />
-            <Button Content="Center On Screen" Click="Center_Click" />
-            <Button Content="Maximize" Click="MaximizeWindow_Click" />
-            <Button Content="Restore" Click="RestoreWindow_Click" />
-            <Button Content="Minimize + Restore (2 second delay)" Click="MinimizeWindow_Click" />
-            <Button Content="Hide + Restore (2 second delay)" Click="HideWindow_Click" />
-            <Button Content="Toggle Tray Icon" Click="ToggleTrayIcon_Click" />
-            <Button Content="Minimime to tray (click tray to reopen)" Click="MinimizeTrayIcon_Click" />
-            <Button Content="Bring to front (2 second delay)" Click="BringToFront_Click" />
-            <Button Content="Show dialog" Click="ShowDialog_Click" />
-        </StackPanel>
-        <Grid Grid.Column="2" RowDefinitions="Auto,*" >
+
+        <ScrollViewer Grid.Column="1">
+            <StackPanel>
+                <StackPanel.Resources>
+                    <Style TargetType="Button">
+                        <Setter Property="HorizontalAlignment" Value="Stretch" />
+                        <Setter Property="Margin" Value="5" />
+                    </Style>
+                </StackPanel.Resources>
+                <TextBox Header="Title:" Text="{x:Bind Title, Mode=TwoWay}" />
+                <Slider
+                    Header="Minimum Width"
+                    Maximum="1024"
+                    Minimum="139"
+                    Value="{x:Bind MinWidth, Mode=TwoWay}" />
+                <Slider
+                    Header="Minimum Height"
+                    Maximum="768"
+                    Minimum="39"
+                    Value="{x:Bind MinHeight, Mode=TwoWay}" />
+                <Button Click="Center_Click" Content="Center On Screen" />
+                <Button Click="MaximizeWindow_Click" Content="Maximize" />
+                <Button Click="RestoreWindow_Click" Content="Restore" />
+                <Button Click="MinimizeWindow_Click" Content="Minimize + Restore (2 second delay)" />
+                <Button Click="HideWindow_Click" Content="Hide + Restore (2 second delay)" />
+                <Button Click="ToggleTrayIcon_Click" Content="Toggle Tray Icon" />
+                <Button Click="MinimizeTrayIcon_Click" Content="Minimize to tray (click tray to reopen)" />
+                <Button Click="BringToFront_Click" Content="Bring to front (2 second delay)" />
+                <Button Click="ShowDialog_Click" Content="Show dialog" />
+                <!--<RadioButtons MaxColumns="3" Header="Move Window To: " >
+                <RadioButton Content="TopLeft"  Checked="moveWindowRadioButtons_Checked"/>
+                <RadioButton Content="TopCenter"  Checked="moveWindowRadioButtons_Checked"/>
+                <RadioButton Content="TopRight"  Checked="moveWindowRadioButtons_Checked"/>
+
+                <RadioButton Content="MiddleLeft"  Checked="moveWindowRadioButtons_Checked"/>
+                <RadioButton Content="MiddleCenter"  Checked="moveWindowRadioButtons_Checked"/>
+                <RadioButton Content="MiddleRight"   Checked="moveWindowRadioButtons_Checked"/>
+
+                <RadioButton Content="BottomLeft"  Checked="moveWindowRadioButtons_Checked"/>
+                <RadioButton Content="BottomCenter"  Checked="moveWindowRadioButtons_Checked"/>
+                <RadioButton Content="BottomRight" Checked="moveWindowRadioButtons_Checked"/>
+                </RadioButtons>-->
+                <TextBlock Text="Move Window To:" />
+                <Grid ColumnDefinitions="*,*,*" RowDefinitions="*,*,*">
+                    <Button Click="moveWindowButton_Clicked" Content="TopLeft" />
+                    <Button
+                        Grid.Column="1"
+                        Click="moveWindowButton_Clicked"
+                        Content="TopCenter" />
+                    <Button
+                        Grid.Column="2"
+                        Click="moveWindowButton_Clicked"
+                        Content="TopRight" />
+
+                    <Button
+                        Grid.Row="1"
+                        Click="moveWindowButton_Clicked"
+                        Content="MiddleLeft" />
+                    <Button
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        Click="moveWindowButton_Clicked"
+                        Content="MiddleCenter" />
+                    <Button
+                        Grid.Row="1"
+                        Grid.Column="2"
+                        Click="moveWindowButton_Clicked"
+                        Content="MiddleRight" />
+
+                    <Button
+                        Grid.Row="2"
+                        Click="moveWindowButton_Clicked"
+                        Content="BottomLeft" />
+                    <Button
+                        Grid.Row="2"
+                        Grid.Column="1"
+                        Click="moveWindowButton_Clicked"
+                        Content="BottomCenter" />
+                    <Button
+                        Grid.Row="2"
+                        Grid.Column="2"
+                        Click="moveWindowButton_Clicked"
+                        Content="BottomRight" />
+
+                </Grid>
+
+
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                    <TextBlock VerticalAlignment="Center" Text="X: "/>
+                    <NumberBox
+                        x:Name="x_box"
+                        Width="100"
+                        Value="300" 
+                        Margin="5"/>
+                    <TextBlock VerticalAlignment="Center" Text="Y: "/>
+                    <NumberBox
+                        x:Name="y_box"
+                        Width="100"
+                        Value="300" 
+                        Margin="5"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                <Button Click="MoveToPoint_Click" Content="Move to XY" />
+                <Button Click="CentreOnPoint_Click" Content="Centre on XY" />                    
+                </StackPanel>
+
+            </StackPanel>
+        </ScrollViewer>
+
+        <Grid Grid.Column="2" RowDefinitions="Auto,*">
             <TextBlock Text="Log" />
-            <TextBox IsReadOnly="True" AcceptsReturn="True" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" x:Name="WindowEventLog" Grid.Row="1" />
+            <TextBox
+                x:Name="WindowEventLog"
+                Grid.Row="1"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch"
+                AcceptsReturn="True"
+                IsReadOnly="True" />
         </Grid>
-        
+
     </Grid>
 </winex:WindowEx>

--- a/src/WinUIExSample/MainWindow.xaml.cs
+++ b/src/WinUIExSample/MainWindow.xaml.cs
@@ -194,5 +194,15 @@ namespace WinUIExSample
             Placement position = (Placement)Enum.Parse(typeof(Placement), button.Content.ToString());
             this.MoveTo(position, x_box.Value, y_box.Value, IsForcedTowardsCenter);
         }
+
+        private bool _IsForcedTowardsCenter = false;
+        /// <summary>
+        /// A bool to set whether offsets are forced away from the specified edge 
+        /// </summary>
+        public bool IsForcedTowardsCenter
+        {
+            get => _IsForcedTowardsCenter;
+            set => _IsForcedTowardsCenter = value;
+        }
     }
 }

--- a/src/WinUIExSample/MainWindow.xaml.cs
+++ b/src/WinUIExSample/MainWindow.xaml.cs
@@ -192,7 +192,7 @@ namespace WinUIExSample
             var button = sender as Button;
             SanitizeXY();
             Placement position = (Placement)Enum.Parse(typeof(Placement), button.Content.ToString());
-            this.MoveTo(position, x_box.Value, y_box.Value);
+            this.MoveTo(position, x_box.Value, y_box.Value, IsForcedTowardsCenter);
         }
     }
 }

--- a/src/WinUIExSample/MainWindow.xaml.cs
+++ b/src/WinUIExSample/MainWindow.xaml.cs
@@ -165,7 +165,11 @@ namespace WinUIExSample
                 monitor.WindowMessageReceived -= WindowMessageReceived;
         }
 
-
+        private void SanitizeXY()
+        {
+            x_box.Value = (Double.IsNaN(x_box.Value))? 0 : x_box.Value;
+            y_box.Value = (Double.IsNaN(y_box.Value))? 0 : y_box.Value;
+        }
         private void WindowMessageReceived(object sender, WindowMessageEventArgs e)
         {
             Log(e.Message.ToString());
@@ -173,27 +177,22 @@ namespace WinUIExSample
 
         private void MoveToPoint_Click(object sender, RoutedEventArgs e)
         {
-            this.Move(x_box.Value, y_box.Value);
+            SanitizeXY();
+            this.MoveTo(x_box.Value, y_box.Value);
         }
 
         private void CentreOnPoint_Click(object sender, RoutedEventArgs e)
         {
+            SanitizeXY();
             this.CenterOnPoint(x_box.Value, y_box.Value);
         }
-
-        //private void moveWindowRadioButtons_Checked(object sender, RoutedEventArgs e)
-        //{
-        //    var rb = sender as RadioButton;
-        //    HwndExtensions.Positions position = (HwndExtensions.Positions)Enum.Parse(typeof(HwndExtensions.Positions), rb.Content.ToString());          
-        //    this.MoveToSelectedPosition(position);
-
-        //}
 
         private void moveWindowButton_Clicked(object sender, RoutedEventArgs e)
         {
             var button = sender as Button;
-            HwndExtensions.Positions position = (HwndExtensions.Positions)Enum.Parse(typeof(HwndExtensions.Positions), button.Content.ToString());
-            this.MoveToPosition(position);
+            SanitizeXY();
+            Placement position = (Placement)Enum.Parse(typeof(Placement), button.Content.ToString());
+            this.MoveTo(position, x_box.Value, y_box.Value);
         }
     }
 }

--- a/src/WinUIExSample/MainWindow.xaml.cs
+++ b/src/WinUIExSample/MainWindow.xaml.cs
@@ -170,5 +170,30 @@ namespace WinUIExSample
         {
             Log(e.Message.ToString());
         }
+
+        private void MoveToPoint_Click(object sender, RoutedEventArgs e)
+        {
+            this.Move(x_box.Value, y_box.Value);
+        }
+
+        private void CentreOnPoint_Click(object sender, RoutedEventArgs e)
+        {
+            this.CenterOnPoint(x_box.Value, y_box.Value);
+        }
+
+        //private void moveWindowRadioButtons_Checked(object sender, RoutedEventArgs e)
+        //{
+        //    var rb = sender as RadioButton;
+        //    HwndExtensions.Positions position = (HwndExtensions.Positions)Enum.Parse(typeof(HwndExtensions.Positions), rb.Content.ToString());          
+        //    this.MoveToSelectedPosition(position);
+
+        //}
+
+        private void moveWindowButton_Clicked(object sender, RoutedEventArgs e)
+        {
+            var button = sender as Button;
+            HwndExtensions.Positions position = (HwndExtensions.Positions)Enum.Parse(typeof(HwndExtensions.Positions), button.Content.ToString());
+            this.MoveToSelectedPosition(position);
+        }
     }
 }

--- a/src/WinUIExSample/MainWindow.xaml.cs
+++ b/src/WinUIExSample/MainWindow.xaml.cs
@@ -193,7 +193,7 @@ namespace WinUIExSample
         {
             var button = sender as Button;
             HwndExtensions.Positions position = (HwndExtensions.Positions)Enum.Parse(typeof(HwndExtensions.Positions), button.Content.ToString());
-            this.MoveToSelectedPosition(position);
+            this.MoveToPosition(position);
         }
     }
 }


### PR DESCRIPTION
Added MoveTo method to move without resizing:
* Move to coordinate
* Move to enum specified edge/position( optional offset, with the option to force movement towards the centre (eg. margins) or move exactly as specified by the XY values)

Added a CentreOn method to centre tthe window on a point.

This **does not** contain any way to move to a specific monitor, as that is beyond my current programming knowledge.  I have no idea how to get a HMonitor array from EnumDisplayMonitors. 

Nothing has been deleted, I added a scrollviewer to the second column of the example app, which made github think the entire enclosed stack panel is new.