### PR TITLE
WebAuthenticator: URI Encode state parameter in query string

### DIFF
--- a/src/WinUIEx/WebAuthenticator.cs
+++ b/src/WinUIEx/WebAuthenticator.cs
@@ -107,7 +107,7 @@ namespace WinUIEx
             {
                 try
                 {
-                    var jsonObject = System.Text.Json.Nodes.JsonObject.Parse(state) as JsonObject;
+                    var jsonObject = System.Text.Json.Nodes.JsonObject.Parse(Uri.UnescapeDataString(state)) as JsonObject;
                     if (jsonObject is not null)
                     {
                         NameValueCollection vals2 = new NameValueCollection(jsonObject.Count);
@@ -239,7 +239,7 @@ namespace WinUIEx
                 stateJson["state"] = oldstate;
             }
             
-            query["state"] = stateJson.ToJsonString();
+            query["state"] = Uri.EscapeUriString(stateJson.ToJsonString());
             b.Query = query.ToString();
             authorizeUri = b.Uri;
 


### PR DESCRIPTION
This seems superfluous, but works around an issue with Firefox where string quotes are being removed resulting in invalid JSON.

Fixes [issue #117](https://github.com/dotMorten/WinUIEx/issues/117).