### PR TITLE
Add BeforeProcessStart hook

### DIFF
--- a/src/WinUIEx/WebAuthenticator.cs
+++ b/src/WinUIEx/WebAuthenticator.cs
@@ -1,4 +1,4 @@
-using Microsoft.Windows.AppLifecycle;
+﻿using Microsoft.Windows.AppLifecycle;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -109,7 +109,17 @@ namespace WinUIEx
             {
                 try
                 {
-                    var jsonObject = System.Text.Json.Nodes.JsonObject.Parse(state) as JsonObject;
+                    JsonObject? jsonObject;
+
+                    try
+                    {
+                        jsonObject = System.Text.Json.Nodes.JsonObject.Parse(state) as JsonObject;
+                    } 
+                    catch (Exception e)
+                    {
+                        jsonObject = System.Text.Json.Nodes.JsonObject.Parse(Uri.UnescapeDataString(state)) as JsonObject;
+                    }
+
                     if (jsonObject is not null)
                     {
                         NameValueCollection vals2 = new NameValueCollection(jsonObject.Count);

--- a/src/WinUIEx/WebAuthenticator.cs
+++ b/src/WinUIEx/WebAuthenticator.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Windows.AppLifecycle;
+using Microsoft.Windows.AppLifecycle;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -25,6 +25,8 @@ namespace WinUIEx
     /// </remarks>
     public sealed class WebAuthenticator
     {
+        public static Func<Uri, Uri>? BeforeProcessStart { get; set; }
+
         /// <summary>
         /// Begin an authentication flow by navigating to the specified url and waiting for a callback/redirect to the callbackUrl scheme.
         /// </summary>
@@ -258,9 +260,11 @@ namespace WinUIEx
                 }
             }
 
+            var newUri = BeforeProcessStart != null ? BeforeProcessStart(authorizeUri) : authorizeUri;
+
             var process = new System.Diagnostics.Process();
             process.StartInfo.FileName = "rundll32.exe";
-            process.StartInfo.Arguments = $"url.dll,FileProtocolHandler \"{authorizeUri.ToString().Replace("\"","%22")}\"";
+            process.StartInfo.Arguments = $"url.dll,FileProtocolHandler \"{newUri.ToString().Replace("\"","%22")}\"";
             process.StartInfo.UseShellExecute = true;
             process.Start();
             tasks.Add(taskId, tcs);


### PR DESCRIPTION
This PR is in a very draft state and serves as a way to demonstrate the functionality we are looking for in order to integrate WinUIEX. Nothing in here is final at all, but I figured it'd be good to have a conversation about whether this would be something you want to merge eventually, so I can work on getting it in better shape.

**The issue**
Auth0 does not send back a `state` parameter when one is being passed to `/logout`. This means there is no `signinId` or `applicationId` available to ensure the correct instance is activated after being redirected back. 

The consequence of that is that after logging out, a new instance is opened.

**The solution**
Auth0's logout URL accepts a `returnTo` parameter that it uses to redirect back. If we append a state querystring parameter to the url inside `returnTo`, it works.

So the goal would be to call logout using a URL like this (ignoring correct URL encoding to keep it readable):

`my.domain/logout?returnTo=myapp://callback?state=STATE_GOES_HERE;`

To achieve that, we need to find a way to intercept between generating the state, and opening the browser, which seems to be impossible. 

This PR adds a `BeforeProcessStart` hook to achieve that.

Because of the above, we also need to escape the state on logout (like was done before in WinUIEx, but reverted).

**How to use it**
Using it would come down to:

```
public class WebAuthenticatorBrowser : IdentityModel.OidcClient.Browser.IBrowser
{
    public async Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken cancellationToken = default)
    {
        try
        {
            if (options.StartUrl.IndexOf("logout") > -1)
            {
                WinUIEx.WebAuthenticator.BeforeProcessStart = (uri) =>
                {
                    var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
                    // The state QueryString as generated by WinUIEx
                    var state = query["state"];
                    // The original returnTo as configured externally
                    var returnTo = query["returnTo"];

                    
                    UriBuilder returnToBuilder = new UriBuilder(returnTo);
                    
                    // Get the original returnTo querystring params, so we can append state to it
                    var returnToQuery = System.Web.HttpUtility.ParseQueryString(new Uri(returnTo).Query);
                    // Append state as a querystring parameter to returnTo
                    // We need to escape it for it to be accepted
                    returnToQuery["state"] = Uri.EscapeDataString(state);
                    // Set the query again on the returnTo url
                    returnToBuilder.Query = returnToQuery.ToString();

                    // Update returnTo in the original query so that it now includes state
                    query["returnTo"] = returnToBuilder.Uri.ToString();

                    UriBuilder logoutUrlBuilder = new UriBuilder(uri);
                    // Set the query again on the logout url
                    logoutUrlBuilder.Query = query.ToString();

                    // Return the Uri so it can be used internally by WinUIEx to start the process and open the browser
                    return logoutUrlBuilder.Uri;
                };
            }

            var result = await WinUIEx.WebAuthenticator.AuthenticateAsync(new Uri(options.StartUrl), new Uri(options.EndUrl));

            var url = new RequestUrl(options.EndUrl)
                .Create(new Parameters(result.Properties));

            return new BrowserResult
            {
                Response = url,
                ResultType = BrowserResultType.Success
            };
        }
        catch (TaskCanceledException)
        {
            return new BrowserResult
            {
                ResultType = BrowserResultType.UserCancel,
                ErrorDescription = "Login canceled by the user."
            };
        }
    }
}
```

I understand there are all kinds of different ways to approach this (e.g. we could also pass the state to the hook, instead of getting the state again from the URL, or we can avoid a hook). I used a hook approach as that might be the most flexible and the least specific to our use-case.

Happy to hear your opinion on the use-case we have, the proposed way to solve it as well as any other solutions you would prefer.

Disclaimer: I am not realy familiar with WinUIEx, so this is my first stab at the source code. So there may be better ways to achieve this. But as I was modifying WinUIEx locally to debug the cause of the behavior I was seeing, I figured I could open a PR with the changes to discuss them.