### PR TITLE
Initial work on the new fast splash screen

### DIFF
--- a/docs/concepts/Splashscreen.md
+++ b/docs/concepts/Splashscreen.md
@@ -1,21 +1,21 @@
 ## Splash Screen
 
 WinUIEx provides two kinds of splash screens:
- - `FastSplashScreen`: A simple splash screen that shows just an image and can be launched before any UI loads.
+ - `SimpleSplashScreen`: A simple splash screen that shows just an image and can be launched before any UI loads.
  - `SplashScreen`: A more advanced splash screen that can show any XAML including a progress bar and status text.
 
 
-### FastSplashScreen
+### SimpleSplashScreen
 
-`FastSplashScreen` will show an image while the app is loading. To use it, create a new `FastSplashScreen` in App.xaml.cs:
+`SimpleSplashScreen` will show an image while the app is loading. To use it, create a new `SimpleSplashScreen` in App.xaml.cs:
 
 ```cs
-private FastSplashScreen vss { get; set; }
+private SimpleSplashScreen vss { get; set; }
 
 public App()
 {
-  fss = FastSplashScreen.ShowDefaultSplashScreen(); // Shows the splash screen you already defined in your app manifest. For unpackaged apps use .ShowSplashScreenImage(imagepath):
-  // fss = FastSplashScreen.ShowSplashScreenImage(full_path_to_image_); // Shows a custom splash screen image. Must be a full-path (no relative paths)
+  fss = SimpleSplashScreen.ShowDefaultSplashScreen(); // Shows the splash screen you already defined in your app manifest. For unpackaged apps use .ShowSplashScreenImage(imagepath):
+  // fss = SimpleSplashScreen.ShowSplashScreenImage(full_path_to_image_); // Shows a custom splash screen image. Must be a full-path (no relative paths)
   this.InitializeComponent();
 }
 ```
@@ -52,7 +52,7 @@ and instead defining your own start method. You'll then be able to display the s
       // If you're using the WebAuthenticator, make sure you call this method first before the splashscreen shows
       if (WebAuthenticator.CheckOAuthRedirectionActivation(true))
         return;
-      var fss = FastSplashScreen.ShowDefaultSplashScreen();
+      var fss = SimpleSplashScreen.ShowDefaultSplashScreen();
       WinRT.ComWrappersSupport.InitializeComWrappers();
       Microsoft.UI.Xaml.Application.Start((p) => {
         var context = new Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext(Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread());

--- a/docs/concepts/Splashscreen.md
+++ b/docs/concepts/Splashscreen.md
@@ -124,7 +124,7 @@ protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs ar
 Lastly, override OnLoading, to create some long-running setup work - once this method completes, the splash screen will close and the window in the type parameter will launch.
 
 Example:
-```
+```cs
 protected override async Task OnLoading()
 {
   //TODO: Do some actual work

--- a/docs/concepts/Splashscreen.md
+++ b/docs/concepts/Splashscreen.md
@@ -87,20 +87,20 @@ Before:
 ```cs
 public sealed partial class SplashScreen : Window
 {
-public SplashScreen()
-{
+  public SplashScreen()
+  {
     this.InitializeComponent();
-}
+  }
 }
 ```
 After:
 ```cs
 public sealed partial class SplashScreen : WinUIEx.SplashScreen
 {
-public SplashScreen(Type window) : base(window)
-{
+  public SplashScreen(Type window) : base(window)
+  {
     this.InitializeComponent();
-}
+  }
 }
 ```
 
@@ -108,16 +108,16 @@ Next in App.xaml.cs, change OnLaunched from:
 ```cs
 protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
 {
-    m_window = new MainWindow();
-    m_window.Activate();
+  m_window = new MainWindow();
+  m_window.Activate();
 }
 ```
 To:
 ```cs
 protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
 {
-     var splash = new SplashScreen(typeof(MainWindow));
-     splash.Completed += (s, e) => m_window = e;
+  var splash = new SplashScreen(typeof(MainWindow));
+  splash.Completed += (s, e) => m_window = e;
 }
 ```
 
@@ -127,12 +127,12 @@ Example:
 ```
 protected override async Task OnLoading()
 {
-     //TODO: Do some actual work
-     for (int i = 0; i < 100; i+=5)
-     {
-         statusText.Text = $"Loading {i}%...";
-         progressBar.Value = i;
-         await Task.Delay(50);
-     }
+  //TODO: Do some actual work
+  for (int i = 0; i < 100; i+=5)
+  {
+    statusText.Text = $"Loading {i}%...";
+    progressBar.Value = i;
+    await Task.Delay(50);
+  }
 }
 ```

--- a/docs/concepts/Splashscreen.md
+++ b/docs/concepts/Splashscreen.md
@@ -1,7 +1,73 @@
 ## Splash Screen
 
+WinUIEx provides two kinds of splash screens:
+ - `FastSplashScreen`: A simple splash screen that shows just an image and can be launched before any UI loads.
+ - `SplashScreen`: A more advanced splash screen that can show any XAML including a progress bar and status text.
+
+
+### FastSplashScreen
+
+`FastSplashScreen` will show an image while the app is loading. To use it, create a new `FastSplashScreen` in App.xaml.cs:
+
+```cs
+private FastSplashScreen vss { get; set; }
+
+public App()
+{
+  fss = FastSplashScreen.ShowDefaultSplashScreen(); // Shows the splash screen you already defined in your app manifest. For unpackaged apps use .ShowSplashScreenImage(imagepath):
+  // fss = FastSplashScreen.ShowSplashScreenImage(full_path_to_image_); // Shows a custom splash screen image. Must be a full-path (no relative paths)
+  this.InitializeComponent();
+}
+```
+
+Once your window is activated, you can remove the splash screen by either calling `.Dispose()` or `Hide()`.
+
+```cs
+protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
+{
+  m_window = new MainWindow();
+  m_window.Activate();
+  Window_Activated += Window_Activated;
+  
+}
+
+private void Window_Activated(object sender, WindowActivatedEventArgs args)
+{
+  ((Window)sender).Activated -= Window_Activated;
+  fss?.Hide();
+  fss = null;
+}
+```
+
+For even faster splash screen, disable the XAML generated main method by defining the `DISABLE_XAML_GENERATED_MAIN` preprocessor directive
+and instead defining your own start method. You'll then be able to display the splash screen as the very first thing before the application is created. For example:
+
+```cs
+#if DISABLE_XAML_GENERATED_MAIN
+  public static class Program
+  {
+    [System.STAThreadAttribute]
+    static void Main(string[] args)
+    {
+      // If you're using the WebAuthenticator, make sure you call this method first before the splashscreen shows
+      if (WebAuthenticator.CheckOAuthRedirectionActivation(true))
+        return;
+      var fss = FastSplashScreen.ShowDefaultSplashScreen();
+      WinRT.ComWrappersSupport.InitializeComWrappers();
+      Microsoft.UI.Xaml.Application.Start((p) => {
+        var context = new Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext(Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread());
+        System.Threading.SynchronizationContext.SetSynchronizationContext(context);
+        new App(fss); // Pass the splash screen to your app so it can close it on activation
+      });
+    }
+  }
+#endif
+```
+
+### SplashScreen
+
 To create a new splash screen, first create a new WinUI Window.
-Next change the baseclass from "Window" to SplashScreen:
+Next change the baseclass from `Window` to `SplashScreen`:
 
 Before:
 ```xml
@@ -21,52 +87,52 @@ Before:
 ```cs
 public sealed partial class SplashScreen : Window
 {
-        public SplashScreen()
-        {
-            this.InitializeComponent();
-        }
+public SplashScreen()
+{
+    this.InitializeComponent();
+}
 }
 ```
 After:
 ```cs
 public sealed partial class SplashScreen : WinUIEx.SplashScreen
 {
-        public SplashScreen(Type window) : base(window)
-        {
-            this.InitializeComponent();
-        }
+public SplashScreen(Type window) : base(window)
+{
+    this.InitializeComponent();
+}
 }
 ```
 
 Next in App.xaml.cs, change OnLaunched from:
 ```cs
-        protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
-        {
-            m_window = new MainWindow();
-            m_window.Activate();
-        }
+protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
+{
+    m_window = new MainWindow();
+    m_window.Activate();
+}
 ```
 To:
 ```cs
-        protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
-        {
-             var splash = new SplashScreen(typeof(MainWindow));
-             splash.Completed += (s, e) => m_window = e;
-        }
+protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
+{
+     var splash = new SplashScreen(typeof(MainWindow));
+     splash.Completed += (s, e) => m_window = e;
+}
 ```
 
 Lastly, override OnLoading, to create some long-running setup work - once this method completes, the splash screen will close and the window in the type parameter will launch.
 
 Example:
 ```
-       protected override async Task OnLoading()
-       {
-            //TODO: Do some actual work
-            for (int i = 0; i < 100; i+=5)
-            {
-                statusText.Text = $"Loading {i}%...";
-                progressBar.Value = i;
-                await Task.Delay(50);
-            }
-       }
+protected override async Task OnLoading()
+{
+     //TODO: Do some actual work
+     for (int i = 0; i < 100; i+=5)
+     {
+         statusText.Text = $"Loading {i}%...";
+         progressBar.Value = i;
+         await Task.Delay(50);
+     }
+}
 ```

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -17,7 +17,7 @@
     <Authors>Morten Nielsen - https://xaml.dev</Authors>
     <Company>Morten Nielsen - https://xaml.dev</Company>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>2.4.2</Version>
+    <Version>2.5.0</Version>
     <!--<PackageValidationBaselineVersion>2.3.4</PackageValidationBaselineVersion>-->
   </PropertyGroup>
 

--- a/src/WinUIEx/FastSplashScreen.cs
+++ b/src/WinUIEx/FastSplashScreen.cs
@@ -30,7 +30,6 @@ namespace WinUIEx
         private TimeSpan tsFadeoutDuration;
         private DateTime tsFadeoutEnd;
         Windows.Win32.Foundation.HWND hWndSplash = Windows.Win32.Foundation.HWND.Null;
-        // private Windows.Win32.UI.WindowsAndMessaging.WNDPROC delegateWndProc;
         private Windows.Win32.Graphics.Gdi.HGDIOBJ hBitmap = Windows.Win32.Graphics.Gdi.HGDIOBJ.Null;
         private nuint initToken = 0;
 #if MEDIAPLAYER
@@ -309,10 +308,6 @@ namespace WinUIEx
             else
             {
                 double nProgress = (tsFadeoutEnd - dtNow).TotalMilliseconds / tsFadeoutDuration.TotalMilliseconds;
-                // BLENDFUNCTION bf = new BLENDFUNCTION();
-                // bf.BlendOp = AC_SRC_OVER;
-                // bf.AlphaFormat = AC_SRC_ALPHA;
-                // bf.SourceConstantAlpha = (byte)(255 * nProgress);
                 var bf = new Windows.Win32.Graphics.Gdi.BLENDFUNCTION()
                 {
                     BlendOp = AC_SRC_OVER,
@@ -355,7 +350,6 @@ namespace WinUIEx
                 hDCMem, ptSrc, new Windows.Win32.Foundation.COLORREF(0), bf, UPDATE_LAYERED_WINDOW_FLAGS.ULW_ALPHA);
 
             PInvoke.ReleaseDC(Windows.Win32.Foundation.HWND.Null, hDCScreen);
-
         }
 
         private unsafe void CenterToScreen(IntPtr hWnd)

--- a/src/WinUIEx/FastSplashScreen.cs
+++ b/src/WinUIEx/FastSplashScreen.cs
@@ -1,0 +1,379 @@
+﻿// Based on an implementation by Castorix: https://github.com/castorix/WinUI3_SplashScreen
+
+//#define MEDIAPLAYER
+using Microsoft.UI.Xaml;
+using System;
+using System.Runtime.InteropServices;
+using System.Xml.Linq;
+using System.Xml.XPath;
+
+#if MEDIAPLAYER
+using MFPlay;
+#endif
+using Windows.Win32;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace WinUIEx
+{
+    /// <summary>
+    /// Simple and fast splash screen for display images during application startup.
+    /// </summary>
+    /// <remarks>
+    /// Once your application window has launched/loaded, The splashscreen should be removed by either disposing this instance or calling <see cref="Hide(TimeSpan)"/>.
+    /// </remarks>
+    /// <seealso cref="SplashScreen"/>
+    public sealed class FastSplashScreen : IDisposable
+    {
+        private const nint COLOR_BACKGROUND = 1;
+
+        private DispatcherTimer? dTimer;
+        private TimeSpan tsFadeoutDuration;
+        private DateTime tsFadeoutEnd;
+        Windows.Win32.Foundation.HWND hWndSplash = Windows.Win32.Foundation.HWND.Null;
+        // private Windows.Win32.UI.WindowsAndMessaging.WNDPROC delegateWndProc;
+        private Windows.Win32.Graphics.Gdi.HGDIOBJ hBitmap = Windows.Win32.Graphics.Gdi.HGDIOBJ.Null;
+        private nuint initToken = 0;
+#if MEDIAPLAYER
+        private MFPlayer? mediaPlayer;
+#endif
+
+        /// <summary>
+        /// Shows the splashscreen image specified in the application manifest.
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        public static FastSplashScreen ShowDefaultSplashScreen()
+        {
+            var image = GetManifestSplashScreen();
+            if (image is null)
+                throw new InvalidOperationException("SplashScreen section not found in AppxManifest.xml");
+            var manager = new Microsoft.Windows.ApplicationModel.Resources.ResourceManager();
+            var context = manager.CreateResourceContext();
+
+            var dpi = PInvoke.GetDpiForWindow(PInvoke.GetDesktopWindow());
+            var scale = (int)(dpi / 96d * 100);
+            context.QualifierValues["Scale"] = scale.ToString();
+            var splashScreenImageResource = manager.MainResourceMap.TryGetValue("Files/" + image.Replace('\\','/'), context);
+            if (splashScreenImageResource is not null && splashScreenImageResource.Kind == Microsoft.Windows.ApplicationModel.Resources.ResourceCandidateKind.FilePath)
+            {
+                return FastSplashScreen.ShowSplashScreenImage(splashScreenImageResource.ValueAsString);
+            }
+            throw new InvalidOperationException("Splash screen image not found in resources");
+        }
+
+        private static string? GetManifestSplashScreen()
+        {
+            var rootFolder = Windows.ApplicationModel.Package.Current?.InstalledLocation.Path ?? AppContext.BaseDirectory;
+            var docPath = System.IO.Path.Combine(rootFolder, "AppxManifest.xml");
+            if (!System.IO.File.Exists(docPath))
+                throw new System.IO.FileNotFoundException("AppxManifest.xml not found");
+
+            var doc = XDocument.Load(docPath, LoadOptions.None);
+            var reader = doc.CreateReader();
+            var namespaceManager = new System.Xml.XmlNamespaceManager(reader.NameTable);
+            namespaceManager.AddNamespace("x", "http://schemas.microsoft.com/appx/manifest/foundation/windows10");
+            namespaceManager.AddNamespace("uap", "http://schemas.microsoft.com/appx/manifest/uap/windows10");
+
+            var element = doc.Root?.XPathSelectElement("/x:Package/x:Applications/x:Application/uap:VisualElements/uap:SplashScreen", namespaceManager);
+            return element?.Attribute(XName.Get("Image"))?.Value;
+        }
+
+        /// <summary>
+        /// Shows a splash screen image at the center of the screen
+        /// </summary>
+        /// <param name="image"></param>
+        /// <returns></returns>
+        public static FastSplashScreen ShowSplashScreenImage(string image)
+        {
+            var s = new FastSplashScreen();
+            s.Initialize();
+            var hBitmap = s.GetBitmap(image);
+            s.DisplaySplash(Windows.Win32.Foundation.HWND.Null, hBitmap, null);
+            return s;
+        }
+#if MEDIAPLAYER
+        public static FastSplashScreen ShowSplashScreenVideo(string video)
+        {
+            var s = new FastSplashScreen();
+            s.Initialize();
+            s.DisplaySplash(Windows.Win32.Foundation.HWND.Null, Windows.Win32.Graphics.Gdi.HBITMAP.Null, video);
+            return s;
+        }
+#endif
+        private void Initialize()
+        {
+            var input = new Windows.Win32.Graphics.GdiPlus.GdiplusStartupInput()
+            {
+                GdiplusVersion = 1,
+                SuppressBackgroundThread = false,
+                SuppressExternalCodecs = false
+            };
+            var output = new Windows.Win32.Graphics.GdiPlus.GdiplusStartupOutput();
+            var nStatus = PInvoke.GdiplusStartup(ref initToken, input, ref output);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            CleanUp();
+            if (disposing)
+            {
+#if MEDIAPLAYER
+                mediaPlayer.Dispose();
+#endif
+            }
+        }
+
+        private void CleanUp()
+        {
+            if (hWndSplash != IntPtr.Zero)
+            {
+                PInvoke.DestroyWindow(hWndSplash);
+            }
+            if (hBitmap != IntPtr.Zero)
+            {
+                PInvoke.DeleteObject(new Windows.Win32.Graphics.Gdi.HGDIOBJ(hBitmap));
+                hBitmap = Windows.Win32.Graphics.Gdi.HGDIOBJ.Null;
+            }
+            PInvoke.GdiplusShutdown(initToken);
+        }
+
+        /// <summary>
+        /// Finalizer
+        /// </summary>
+        ~FastSplashScreen() => Dispose(false);
+
+        private unsafe void DisplaySplash(Windows.Win32.Foundation.HWND hWnd, Windows.Win32.Graphics.Gdi.HBITMAP bitmap, string? sVideo)
+        {
+            Windows.Win32.UI.WindowsAndMessaging.WNDCLASSEXW wcex;
+            this.hBitmap = bitmap;
+            wcex.cbSize = (uint)Marshal.SizeOf(typeof(WNDCLASSEXW));
+            wcex.style = WNDCLASS_STYLES.CS_HREDRAW | WNDCLASS_STYLES.CS_VREDRAW | WNDCLASS_STYLES.CS_DBLCLKS;
+            wcex.hbrBackground = new Windows.Win32.Graphics.Gdi.HBRUSH(COLOR_BACKGROUND + 1);
+            wcex.cbClsExtra = 0;
+            wcex.cbWndExtra = 0;
+            wcex.hInstance = new Windows.Win32.Foundation.HINSTANCE(Marshal.GetHINSTANCE(this.GetType().Module));
+            wcex.hIcon = HICON.Null;
+            wcex.hCursor = HCURSOR.Null;
+            wcex.lpszMenuName = null;
+            string sClassName = "Win32Class";
+            fixed (char* name = sClassName)
+                wcex.lpszClassName = name;
+            wcex.lpfnWndProc = &Win32WndProc;
+
+            wcex.hIconSm = HICON.Null;
+            ushort nRet = PInvoke.RegisterClassEx(wcex);
+            if (nRet == 0)
+            {
+                int nError = Marshal.GetLastWin32Error();
+                if (nError != 1410) //0x582 ERROR_CLASS_ALREADY_EXISTS
+                    return;
+            }
+            int nWidth = 0, nHeight = 0;
+            if (hBitmap != IntPtr.Zero)
+            {
+                BITMAP bm;
+                PInvoke.GetObject(new DeleteObjectSafeHandle(hBitmap), Marshal.SizeOf(typeof(BITMAP)), &bm);
+                nWidth = bm.bmWidth;
+                nHeight = bm.bmHeight;
+            }
+            
+            hWndSplash = PInvoke.CreateWindowEx(WINDOW_EX_STYLE.WS_EX_TOOLWINDOW | WINDOW_EX_STYLE.WS_EX_LAYERED | WINDOW_EX_STYLE.WS_EX_TRANSPARENT | WINDOW_EX_STYLE.WS_EX_TOPMOST,
+                sClassName, "Win32 window", WINDOW_STYLE.WS_POPUP | WINDOW_STYLE.WS_VISIBLE, 400, 400, nWidth, nHeight, hWnd, null,
+                new DestroyIconSafeHandle(wcex.hInstance), null);
+            if (hBitmap != IntPtr.Zero)
+            {
+                SetPictureToLayeredWindow(hWndSplash, hBitmap);
+                CenterToScreen(hWndSplash);
+            }
+#if MEDIAPLAYER
+            if (sVideo != null)
+            {
+                mediaPlayer = new MFPlayer(this, hWndSplash, sVideo);
+            }
+#endif
+        }
+        [StructLayoutAttribute(LayoutKind.Sequential)]
+        private struct BITMAP
+        {
+            public int bmType;
+            public int bmWidth;
+            public int bmHeight;
+            public int bmWidthBytes;
+            public short bmPlanes;
+            public short bmBitsPixel;
+            public IntPtr bmBits;
+        }
+
+#if MEDIAPLAYER
+        private class MFPlayer : IMFPMediaPlayerCallback, IDisposable
+        {
+            private readonly FastSplashScreen m_ss;
+            private readonly Windows.Win32.Foundation.HWND m_hWndParent;
+            private readonly IMFPMediaPlayer m_pMediaPlayer;
+
+            internal unsafe MFPlayer(FastSplashScreen ss, Windows.Win32.Foundation.HWND hWnd, string sVideo)
+            {
+                GlobalStructures.HRESULT hr = MFPlayTools.MFPCreateMediaPlayer(sVideo, false, MFPlay.MFPlayTools.MFP_CREATION_OPTIONS.MFP_OPTION_NONE, this, hWnd, out m_pMediaPlayer);
+                m_hWndParent = hWnd;
+                m_ss = ss;
+            }
+
+            void IMFPMediaPlayerCallback.OnMediaPlayerEvent(MFP_EVENT_HEADER pEventHeader)
+            {
+                switch (pEventHeader.eEventType)
+                {
+                    case MFP_EVENT_TYPE.MFP_EVENT_TYPE_MEDIAITEM_SET:
+                        {
+                            GlobalStructures.SIZE szVideo, szARVideo;
+                            GlobalStructures.HRESULT hr = m_pMediaPlayer.GetNativeVideoSize(out szVideo, out szARVideo);
+                            if (hr == GlobalStructures.HRESULT.S_OK)
+                            {
+                                PInvoke.SetWindowPos(m_hWndParent, Windows.Win32.Foundation.HWND.Null, 0, 0, szVideo.cx, szVideo.cy, SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOZORDER | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
+                                m_ss.CenterToScreen(m_hWndParent);
+                                hr = m_pMediaPlayer.Play();
+                            }
+                        }
+                        break;
+                    case MFP_EVENT_TYPE.MFP_EVENT_TYPE_PLAYBACK_ENDED:
+                        {
+                            PlaybackEnded?.Invoke(this, EventArgs.Empty);
+                        }
+                        break;
+                }
+                return;
+            }
+
+            ~MFPlayer() => Dispose(false);
+
+            public void Dispose() => Dispose(true);
+
+            private void Dispose(bool disposing) => m_pMediaPlayer.Shutdown();
+
+            public event EventHandler PlaybackEnded;
+        }
+#endif
+
+        /// <summary>
+        /// Hides the splashscreen
+        /// </summary>
+        /// <param name="fadeTimout">Time spend fading out the splash screen (defaults to no fade)</param>
+        public void Hide(TimeSpan fadeTimout = default)
+        {
+            if (fadeTimout.Ticks <= 0)
+                CleanUp();
+            else
+            {
+                dTimer = new DispatcherTimer();
+                dTimer.Interval = TimeSpan.FromMilliseconds(16);
+                tsFadeoutDuration = fadeTimout;
+                tsFadeoutEnd = DateTime.UtcNow + tsFadeoutDuration;
+                dTimer.Tick += FadeTimer_Tick;
+                dTimer.Start();
+            }
+        }
+
+        private unsafe Windows.Win32.Graphics.Gdi.HBITMAP GetBitmap(string sBitmapFile)
+        {
+            var bitmap = new Windows.Win32.Graphics.GdiPlus.GpBitmap();
+            var pBitmap = &bitmap;
+
+            var nStatus = PInvoke.GdipCreateBitmapFromFile(sBitmapFile, ref pBitmap);
+
+            if (nStatus == Windows.Win32.Graphics.GdiPlus.Status.Ok)
+            {
+                var hBitmap = new Windows.Win32.Graphics.Gdi.HBITMAP();
+                PInvoke.GdipCreateHBITMAPFromBitmap(pBitmap, &hBitmap, (uint)System.Drawing.ColorTranslator.ToWin32(System.Drawing.Color.FromArgb(0)));
+                return hBitmap;
+            }
+            throw new InvalidOperationException("Failed to open bitmap: " + nStatus.ToString());
+        }
+
+        private void FadeTimer_Tick(object? sender, object e)
+        {
+            DateTime dtNow = DateTime.UtcNow;
+            if (dtNow >= tsFadeoutEnd)
+            {
+                if (dTimer != null)
+                {
+                    dTimer.Stop();
+                    dTimer = null;
+                }
+                CleanUp();
+            }
+            else
+            {
+                double nProgress = (tsFadeoutEnd - dtNow).TotalMilliseconds / tsFadeoutDuration.TotalMilliseconds;
+                // BLENDFUNCTION bf = new BLENDFUNCTION();
+                // bf.BlendOp = AC_SRC_OVER;
+                // bf.AlphaFormat = AC_SRC_ALPHA;
+                // bf.SourceConstantAlpha = (byte)(255 * nProgress);
+                var bf = new Windows.Win32.Graphics.Gdi.BLENDFUNCTION()
+                {
+                    BlendOp = AC_SRC_OVER,
+                    SourceConstantAlpha = (byte)(255 * nProgress),
+                    AlphaFormat = AC_SRC_ALPHA
+                };
+
+                PInvoke.UpdateLayeredWindow(hWndSplash,
+                    new Windows.Win32.Graphics.Gdi.HDC(0), null, null, new Windows.Win32.Graphics.Gdi.HDC(0), (System.Drawing.Point?)null, new Windows.Win32.Foundation.COLORREF(0), bf, UPDATE_LAYERED_WINDOW_FLAGS.ULW_ALPHA);
+            }
+        }
+
+        private const byte AC_SRC_OVER = 0x00;
+        private const byte AC_SRC_ALPHA = 0x01;
+
+        private unsafe void SetPictureToLayeredWindow(Windows.Win32.Foundation.HWND hWnd, IntPtr hBitmap)
+        {
+            BITMAP bm;
+            Windows.Win32.Graphics.Gdi.HBITMAP bitmap = new Windows.Win32.Graphics.Gdi.HBITMAP(hBitmap);
+            PInvoke.GetObject(new Windows.Win32.DeleteObjectSafeHandle(hBitmap), Marshal.SizeOf(typeof(BITMAP)), &bm);
+            System.Drawing.Size sizeBitmap = new System.Drawing.Size(bm.bmWidth, bm.bmHeight);
+
+            var hDCScreen = PInvoke.GetDC(Windows.Win32.Foundation.HWND.Null);
+            var hDCMem = PInvoke.CreateCompatibleDC(hDCScreen);
+            using var hBitmapOld = PInvoke.SelectObject(hDCMem, new DestroyIconSafeHandle(hBitmap));
+
+            var bf = new Windows.Win32.Graphics.Gdi.BLENDFUNCTION()
+            {
+                BlendOp = AC_SRC_OVER,
+                SourceConstantAlpha = 255,
+                AlphaFormat = AC_SRC_ALPHA
+            };
+            PInvoke.GetWindowRect(hWnd, out var rectWnd);
+
+            System.Drawing.Point ptSrc = new System.Drawing.Point();
+            System.Drawing.Point ptDest = new System.Drawing.Point(rectWnd.left, rectWnd.top);
+
+            bool bRet = PInvoke.UpdateLayeredWindow(hWnd,
+                hDCScreen, ptDest, new Windows.Win32.Foundation.SIZE(sizeBitmap.Width, sizeBitmap.Height),
+                hDCMem, ptSrc, new Windows.Win32.Foundation.COLORREF(0), bf, UPDATE_LAYERED_WINDOW_FLAGS.ULW_ALPHA);
+
+            PInvoke.ReleaseDC(Windows.Win32.Foundation.HWND.Null, hDCScreen);
+
+        }
+
+        private unsafe void CenterToScreen(IntPtr hWnd)
+        {
+            var rcWorkArea = new Windows.Win32.Foundation.RECT();
+            PInvoke.SystemParametersInfo(SYSTEM_PARAMETERS_INFO_ACTION.SPI_GETWORKAREA, 0, &rcWorkArea, 0);
+            var h = new Windows.Win32.Foundation.HWND(hWnd);
+            PInvoke.GetWindowRect(h, out Windows.Win32.Foundation.RECT rc);
+            int nX = System.Convert.ToInt32((rcWorkArea.left + rcWorkArea.right) / (double)2 - (rc.right - rc.left) / (double)2);
+            int nY = System.Convert.ToInt32((rcWorkArea.top + rcWorkArea.bottom) / (double)2 - (rc.bottom - rc.top) / (double)2);
+            PInvoke.SetWindowPos(h, Windows.Win32.Foundation.HWND.Null, nX, nY, -1, -1, SET_WINDOW_POS_FLAGS.SWP_NOSIZE | SET_WINDOW_POS_FLAGS.SWP_NOZORDER | SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
+        }
+
+        [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static Windows.Win32.Foundation.LRESULT Win32WndProc(Windows.Win32.Foundation.HWND hwnd,
+            uint msg, Windows.Win32.Foundation.WPARAM wParam, Windows.Win32.Foundation.LPARAM lParam)
+        {
+            return PInvoke.DefWindowProc(hwnd, msg, wParam, lParam);
+        }
+    }
+}

--- a/src/WinUIEx/NativeMethods.txt
+++ b/src/WinUIEx/NativeMethods.txt
@@ -65,3 +65,4 @@ WNDCLASSEXW
 RegisterClassEx
 CreateCompatibleDC
 SelectObject
+MonitorFromPoint

--- a/src/WinUIEx/NativeMethods.txt
+++ b/src/WinUIEx/NativeMethods.txt
@@ -55,3 +55,13 @@ CreateRectRgn
 CreateSolidBrush
 FillRect
 GetDC
+ReleaseDC
+GdiplusStartup
+GdiplusShutdown
+GetObject
+GdipCreateBitmapFromFile
+GdipCreateHBITMAPFromBitmap
+WNDCLASSEXW
+RegisterClassEx
+CreateCompatibleDC
+SelectObject

--- a/src/WinUIEx/SimpleSplashScreen.cs
+++ b/src/WinUIEx/SimpleSplashScreen.cs
@@ -195,8 +195,8 @@ namespace WinUIEx
                 new DestroyIconSafeHandle(wcex.hInstance), null);
             if (hBitmap != IntPtr.Zero)
             {
-                SetPictureToLayeredWindow(hWndSplash, hBitmap);
                 CenterToScreen(hWndSplash);
+                SetPictureToLayeredWindow(hWndSplash, hBitmap);
             }
 #if MEDIAPLAYER
             if (sVideo != null)

--- a/src/WinUIEx/SimpleSplashScreen.cs
+++ b/src/WinUIEx/SimpleSplashScreen.cs
@@ -49,8 +49,16 @@ namespace WinUIEx
             var manager = new Microsoft.Windows.ApplicationModel.Resources.ResourceManager();
             var context = manager.CreateResourceContext();
 
-            var dpi = PInvoke.GetDpiForWindow(PInvoke.GetDesktopWindow());
+            uint dpi = 96;
+            var monitor = PInvoke.MonitorFromPoint(new System.Drawing.Point(0, 0), Windows.Win32.Graphics.Gdi.MONITOR_FROM_FLAGS.MONITOR_DEFAULTTOPRIMARY);
+            
+            if(monitor != IntPtr.Zero)
+            {
+                PInvoke.GetDpiForMonitor(monitor, Windows.Win32.UI.HiDpi.MONITOR_DPI_TYPE.MDT_EFFECTIVE_DPI, out var dpiX, out var dpiy);
+                dpi = dpiX;
+            }
             var scale = (int)(dpi / 96d * 100);
+            if (scale == 0) scale = 100;
             context.QualifierValues["Scale"] = scale.ToString();
             var splashScreenImageResource = manager.MainResourceMap.TryGetValue("Files/" + image.Replace('\\','/'), context);
             if (splashScreenImageResource is not null && splashScreenImageResource.Kind == Microsoft.Windows.ApplicationModel.Resources.ResourceCandidateKind.FilePath)

--- a/src/WinUIEx/SimpleSplashScreen.cs
+++ b/src/WinUIEx/SimpleSplashScreen.cs
@@ -22,7 +22,7 @@ namespace WinUIEx
     /// Once your application window has launched/loaded, The splashscreen should be removed by either disposing this instance or calling <see cref="Hide(TimeSpan)"/>.
     /// </remarks>
     /// <seealso cref="SplashScreen"/>
-    public sealed class FastSplashScreen : IDisposable
+    public sealed class SimpleSplashScreen : IDisposable
     {
         private const nint COLOR_BACKGROUND = 1;
 
@@ -41,7 +41,7 @@ namespace WinUIEx
         /// </summary>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException"></exception>
-        public static FastSplashScreen ShowDefaultSplashScreen()
+        public static SimpleSplashScreen ShowDefaultSplashScreen()
         {
             var image = GetManifestSplashScreen();
             if (image is null)
@@ -55,7 +55,7 @@ namespace WinUIEx
             var splashScreenImageResource = manager.MainResourceMap.TryGetValue("Files/" + image.Replace('\\','/'), context);
             if (splashScreenImageResource is not null && splashScreenImageResource.Kind == Microsoft.Windows.ApplicationModel.Resources.ResourceCandidateKind.FilePath)
             {
-                return FastSplashScreen.ShowSplashScreenImage(splashScreenImageResource.ValueAsString);
+                return SimpleSplashScreen.ShowSplashScreenImage(splashScreenImageResource.ValueAsString);
             }
             throw new InvalidOperationException("Splash screen image not found in resources");
         }
@@ -82,18 +82,18 @@ namespace WinUIEx
         /// </summary>
         /// <param name="image"></param>
         /// <returns></returns>
-        public static FastSplashScreen ShowSplashScreenImage(string image)
+        public static SimpleSplashScreen ShowSplashScreenImage(string image)
         {
-            var s = new FastSplashScreen();
+            var s = new SimpleSplashScreen();
             s.Initialize();
             var hBitmap = s.GetBitmap(image);
             s.DisplaySplash(Windows.Win32.Foundation.HWND.Null, hBitmap, null);
             return s;
         }
 #if MEDIAPLAYER
-        public static FastSplashScreen ShowSplashScreenVideo(string video)
+        public static SimpleSplashScreen ShowSplashScreenVideo(string video)
         {
-            var s = new FastSplashScreen();
+            var s = new SimpleSplashScreen();
             s.Initialize();
             s.DisplaySplash(Windows.Win32.Foundation.HWND.Null, Windows.Win32.Graphics.Gdi.HBITMAP.Null, video);
             return s;
@@ -145,7 +145,7 @@ namespace WinUIEx
         /// <summary>
         /// Finalizer
         /// </summary>
-        ~FastSplashScreen() => Dispose(false);
+        ~SimpleSplashScreen() => Dispose(false);
 
         private unsafe void DisplaySplash(Windows.Win32.Foundation.HWND hWnd, Windows.Win32.Graphics.Gdi.HBITMAP bitmap, string? sVideo)
         {
@@ -212,11 +212,11 @@ namespace WinUIEx
 #if MEDIAPLAYER
         private class MFPlayer : IMFPMediaPlayerCallback, IDisposable
         {
-            private readonly FastSplashScreen m_ss;
+            private readonly SimpleSplashScreen m_ss;
             private readonly Windows.Win32.Foundation.HWND m_hWndParent;
             private readonly IMFPMediaPlayer m_pMediaPlayer;
 
-            internal unsafe MFPlayer(FastSplashScreen ss, Windows.Win32.Foundation.HWND hWnd, string sVideo)
+            internal unsafe MFPlayer(SimpleSplashScreen ss, Windows.Win32.Foundation.HWND hWnd, string sVideo)
             {
                 GlobalStructures.HRESULT hr = MFPlayTools.MFPCreateMediaPlayer(sVideo, false, MFPlay.MFPlayTools.MFP_CREATION_OPTIONS.MFP_OPTION_NONE, this, hWnd, out m_pMediaPlayer);
                 m_hWndParent = hWnd;

--- a/src/WinUIEx/SplashScreen.cs
+++ b/src/WinUIEx/SplashScreen.cs
@@ -10,7 +10,7 @@ namespace WinUIEx
     /// A splash screen window for rendering XAML that shows with no chrome, and once <see cref="SplashScreen.OnLoading"/> has completed,
     /// opens a new window.
     /// </summary>
-    /// <seealso cref="FastSplashScreen"/>
+    /// <seealso cref="SimpleSplashScreen"/>
     public class SplashScreen : Window
     {
         private Window? _window;

--- a/src/WinUIEx/SplashScreen.cs
+++ b/src/WinUIEx/SplashScreen.cs
@@ -7,9 +7,10 @@ using Microsoft.UI.Xaml;
 namespace WinUIEx
 {
     /// <summary>
-    /// A splash screen window that shows with no chrome, and once <see cref="SplashScreen.OnLoading"/> has completed,
-    /// opens a new window
+    /// A splash screen window for rendering XAML that shows with no chrome, and once <see cref="SplashScreen.OnLoading"/> has completed,
+    /// opens a new window.
     /// </summary>
+    /// <seealso cref="FastSplashScreen"/>
     public class SplashScreen : Window
     {
         private Window? _window;

--- a/src/WinUIEx/WinUIEx.csproj
+++ b/src/WinUIEx/WinUIEx.csproj
@@ -25,7 +25,7 @@
     <PackageId>WinUIEx</PackageId>
     <Product>WinUI Extensions</Product>
     <PackageReleaseNotes>
-      - Workaround package bug in WebView2 nuget package. (Issue #188)
+      - Added `SimpleSplashScreen` for display application launch splash screens
     </PackageReleaseNotes>
   </PropertyGroup>
 
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$(WinAppSDKVersion)" />
 	<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2651.64" IncludeAssets="none" /> <!-- Work around bug in webview package, and we don't really need this anyway -->
     <None Include="README.md" Pack="true" PackagePath="\" />
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" >
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/WinUIExSample/App.xaml.cs
+++ b/src/WinUIExSample/App.xaml.cs
@@ -26,7 +26,7 @@ namespace WinUIExSample
 #if !DISABLE_XAML_GENERATED_MAIN // With custom main, we'd rather want to do this code in main
             if (WebAuthenticator.CheckOAuthRedirectionActivation())
                 return;
-            fss = FastSplashScreen.ShowDefaultSplashScreen();
+            fss = SimpleSplashScreen.ShowDefaultSplashScreen();
 #endif
             this.InitializeComponent();
             int length = 0;
@@ -39,7 +39,7 @@ namespace WinUIExSample
             }
 
         }
-        internal FastSplashScreen fss { get; set; }
+        internal SimpleSplashScreen fss { get; set; }
         /// <summary>
         /// Invoked when the application is launched normally by the end user.  Other entry points
         /// will be used such as when the application is launched to open a specific file.
@@ -156,7 +156,7 @@ namespace WinUIExSample
         {
             if (WebAuthenticator.CheckOAuthRedirectionActivation(true))
                 return;
-            var fss = FastSplashScreen.ShowDefaultSplashScreen();
+            var fss = SimpleSplashScreen.ShowDefaultSplashScreen();
             global::WinRT.ComWrappersSupport.InitializeComWrappers();
             global::Microsoft.UI.Xaml.Application.Start((p) => {
                 var context = new global::Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext(global::Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread());

--- a/src/WinUIExSample/App.xaml.cs
+++ b/src/WinUIExSample/App.xaml.cs
@@ -25,6 +25,7 @@ namespace WinUIExSample
         {
             if (WebAuthenticator.CheckOAuthRedirectionActivation())
                 return;
+            fss = FastSplashScreen.ShowDefaultSplashScreen();
             this.InitializeComponent();
             int length = 0;
             var sb = new System.Text.StringBuilder(0);
@@ -34,8 +35,9 @@ namespace WinUIExSample
                 // Not a packaged app. Configure file-based persistence instead
                 WinUIEx.WindowManager.PersistenceStorage = new FilePersistence("WinUIExPersistence.json");
             }
+
         }
-        
+        FastSplashScreen fss;
         /// <summary>
         /// Invoked when the application is launched normally by the end user.  Other entry points
         /// will be used such as when the application is launched to open a specific file.
@@ -45,7 +47,18 @@ namespace WinUIExSample
         {
             var window = new MainWindow();
             var splash = new SplashScreen(window);
-            splash.Completed += (s, e) => m_window = (WindowEx)e;
+            splash.Completed += (s, e) =>
+            {
+                m_window = (WindowEx)e;
+            };
+            splash.Activated += Splash_Activated;
+        }
+
+        private void Splash_Activated(object sender, WindowActivatedEventArgs args)
+        {
+            ((Window)sender).Activated -= Splash_Activated;
+            fss?.Hide(TimeSpan.FromSeconds(1));
+            fss = null;
         }
 
         private WindowEx m_window;

--- a/src/WinUIExSample/App.xaml.cs
+++ b/src/WinUIExSample/App.xaml.cs
@@ -23,9 +23,11 @@ namespace WinUIExSample
         /// </summary>
         public App()
         {
+#if !DISABLE_XAML_GENERATED_MAIN // With custom main, we'd rather want to do this code in main
             if (WebAuthenticator.CheckOAuthRedirectionActivation())
                 return;
             fss = FastSplashScreen.ShowDefaultSplashScreen();
+#endif
             this.InitializeComponent();
             int length = 0;
             var sb = new System.Text.StringBuilder(0);
@@ -37,7 +39,7 @@ namespace WinUIExSample
             }
 
         }
-        FastSplashScreen fss;
+        internal FastSplashScreen fss { get; set; }
         /// <summary>
         /// Invoked when the application is launched normally by the end user.  Other entry points
         /// will be used such as when the application is launched to open a specific file.
@@ -142,4 +144,26 @@ namespace WinUIExSample
             IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException(); // TODO
         }
     }
+
+#if DISABLE_XAML_GENERATED_MAIN
+    /// <summary>
+    /// Program class
+    /// </summary>
+    public static class Program
+    {
+        [global::System.STAThreadAttribute]
+        static void Main(string[] args)
+        {
+            if (WebAuthenticator.CheckOAuthRedirectionActivation(true))
+                return;
+            var fss = FastSplashScreen.ShowDefaultSplashScreen();
+            global::WinRT.ComWrappersSupport.InitializeComWrappers();
+            global::Microsoft.UI.Xaml.Application.Start((p) => {
+                var context = new global::Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext(global::Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread());
+                global::System.Threading.SynchronizationContext.SetSynchronizationContext(context);
+                new App() { fss = fss };
+            });
+        }
+    }
+#endif
 }

--- a/src/WinUIExSample/WinUIExSample.csproj
+++ b/src/WinUIExSample/WinUIExSample.csproj
@@ -17,6 +17,7 @@
     <!-- Uncomment to run unpackaged: -->
     <!--<WindowsPackageType>None</WindowsPackageType>-->
     <WindowsSdkPackageVersion>10.0.22621.38</WindowsSdkPackageVersion>
+    <DefineConstants>DISABLE_XAML_GENERATED_MAIN;$(DefineConstants)</DefineConstants>
     <PublishAot Condition="'$(RuntimeIdentifier)'=='win-x64'">true</PublishAot>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes #87

Usage:
```cs
public SimpleSplashScreen Splash { get; }
public App()
{
    Splash = SimpleSplashScreen.ShowDefaultSplashScreen(); // Shows splashscreen with closest matching scale from app manifest.
    this.InitializeComponent();
}
```
In MainWindow when your window has loaded, call
`MyApp.Splash.Hide();` (with optional timespan parameter to fade out)

There's also an option to just specify an image path and not rely on app manifest (unpackaged apps would need that):
`SimpleSplashScreen.ShowSplashScreenImage(full_path_to_image);`