### PR TITLE
Add GetWindowRect to Get Position & Size of the Window

### DIFF
--- a/src/WinUIEx/HwndExtensions.cs
+++ b/src/WinUIEx/HwndExtensions.cs
@@ -81,6 +81,27 @@ namespace WinUIEx
         public static void SetAlwaysOnTop(IntPtr hwnd, bool enable)
             => SetWindowPosOrThrow(new HWND(hwnd), new HWND(new IntPtr(enable ? -1 : -2)), 0, 0, 0, 0, SET_WINDOW_POS_FLAGS.SWP_NOSIZE | SET_WINDOW_POS_FLAGS.SWP_NOMOVE);
 
+        /// <summary>
+        /// Get the bounding rectangle of the window in device independent pixels
+        /// </summary>
+        /// <param name="hwnd">Window handle</param>
+        /// <returns>The bounding rectangle of the window</returns>
+        public static Windows.Foundation.Rect GetWindowRect(IntPtr hwnd)
+        {
+            var rect = GetWindowRectOrThrow(new HWND(hwnd));
+            var dpi = GetDpiForWindow(hwnd);
+            var scalingFactor = 96d / dpi;
+            return new Windows.Foundation.Rect(rect.left, rect.top, (int)((rect.right - rect.left) * scalingFactor), (int)((rect.bottom - rect.top) * scalingFactor));
+        }
+
+        private static RECT GetWindowRectOrThrow(HWND hWnd)
+        {
+            bool result = PInvoke.GetWindowRect(hWnd, out RECT rect);
+            if (!result)
+                Marshal.ThrowExceptionForHR(Marshal.GetLastWin32Error());
+            return rect;
+        }
+
         private static void SetWindowPosOrThrow(HWND hWnd, HWND hWndInsertAfter, int X, int Y, int cx, int cy, SET_WINDOW_POS_FLAGS uFlags)
         {
             bool result = PInvoke.SetWindowPos(hWnd, hWndInsertAfter, X, Y, cx, cy, uFlags);

--- a/src/WinUIEx/WindowExtensions.cs
+++ b/src/WinUIEx/WindowExtensions.cs
@@ -177,6 +177,14 @@ namespace WinUIEx
         }
 
         /// <summary>
+        /// Get the bounding rectangle of the window in device independent pixels
+        /// </summary>
+        /// <param name="window">Window</param>
+        /// <returns>The bounding rectangle of the window</returns>
+        public static Windows.Foundation.Rect GetWindowRect(this Microsoft.UI.Xaml.Window window)
+            => HwndExtensions.GetWindowRect(window.GetWindowHandle());
+
+        /// <summary>
         /// Sets the window presenter kind used.
         /// </summary>
         /// <param name="window"></param>


### PR DESCRIPTION
In WindowExtensions & HwndExtensions, there are only functions to set the position & size of the window.
But there aren't any functions to get the position & size of the size.
From https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowrect,
this pull request adds the function to get the position & size of the window in device independence pixels.