### PR TITLE
Disable Tab navigation to window content container control

### DIFF
--- a/src/WinUIEx/WindowEx.cs
+++ b/src/WinUIEx/WindowEx.cs
@@ -55,7 +55,8 @@ namespace WinUIEx
             windowArea = new ContentControl()
             {
                 HorizontalContentAlignment = HorizontalAlignment.Stretch,
-                VerticalContentAlignment = VerticalAlignment.Stretch
+                VerticalContentAlignment = VerticalAlignment.Stretch,
+                IsTabStop = false
             };
             Grid.SetRow(windowArea, 1);
             rootContent.Children.Add(windowArea);


### PR DESCRIPTION
The `windowArea` control serves only as a container and is not interactive. There’s no need for it to receive keyboard focus.

Fixes #225 